### PR TITLE
The failing_node field is not inserted to the events anymore - adjusting...

### DIFF
--- a/cosmo_tester/test_suites/test_blueprints/nodecellar_test_autoheal.py
+++ b/cosmo_tester/test_suites/test_blueprints/nodecellar_test_autoheal.py
@@ -40,11 +40,9 @@ class OpenStackAutohealNodeCellarTest(OpenStackNodeCellarTestBase):
                                 'cloudify.policies.triggers.execute_workflow',
                             'parameters': {
                                 'workflow': 'heal',
-                                'allow_custom_parameters': True,
                                 'workflow_parameters': {
                                     'node_id': {
-                                        'get_property':
-                                            ['SELF', 'failing_node']
+                                        'get_property': ['SELF', 'node_id']
                                     },
                                     'diagnose_value': {
                                         'get_property': ['SELF', 'diagnose']


### PR DESCRIPTION
This change should be compliant with any version of cloudify-manager and is needed for this PR https://github.com/cloudify-cosmo/cloudify-manager/pull/203 to be merged.