### PR TITLE
CFY-2613 added external network property to the simple manager inputs.

### DIFF
--- a/cosmo_tester/resources/blueprints/openstack-start-vm/blueprint.yaml
+++ b/cosmo_tester/resources/blueprints/openstack-start-vm/blueprint.yaml
@@ -9,6 +9,8 @@ inputs:
   prefix:
     description: >
       Unique test id to be added as a prefix for resource names.
+  external_network:
+    type: string
   os_username:
     type: string
   os_password:
@@ -31,7 +33,7 @@ node_templates:
     type: cloudify.openstack.nodes.Network
     properties:
       use_external_resource: true
-      resource_id: public
+      resource_id: { get_input: external_network }
       openstack_config: &OPENSTACK_CONFIG
         username: { get_input: os_username }
         password: { get_input: os_password }
@@ -80,12 +82,13 @@ node_templates:
     properties:
       resource_id: { concat: [{ get_input: prefix }, '-simple-vm-security-group'] }
       rules:
-      rules:
         - port: 80
           remote_ip_prefix: 0.0.0.0/0
         - port: 22
           remote_ip_prefix: 0.0.0.0/0
         - port: 8080
+          remote_ip_prefix: 0.0.0.0/0
+        - port: 8086
           remote_ip_prefix: 0.0.0.0/0
         - port: 8101
           remote_ip_prefix: { get_property: [subnet, subnet, cidr] }

--- a/cosmo_tester/test_suites/test_simple_manager_blueprint/nodecellar_singlehost_test.py
+++ b/cosmo_tester/test_suites/test_simple_manager_blueprint/nodecellar_singlehost_test.py
@@ -39,6 +39,7 @@ class NodecellarSingleHostTest(NodecellarAppTest):
 
         self.inputs = {
             'prefix': self.prefix,
+            'external_network': self.env.external_network_name,
             'os_username': self.env.keystone_username,
             'os_password': self.env.keystone_password,
             'os_tenant_name': self.env.keystone_tenant_name,
@@ -58,7 +59,7 @@ class NodecellarSingleHostTest(NodecellarAppTest):
             name=self._testMethodName,
             ignored_modules=cli_constants.IGNORED_LOCAL_WORKFLOW_MODULES)
 
-        self.logger.info('starting vm to serve as the managmenet vm')
+        self.logger.info('starting vm to serve as the management vm')
         self.local_env.execute('install',
                                task_retries=10,
                                task_retry_interval=30)
@@ -140,7 +141,7 @@ class NodecellarSingleHostTest(NodecellarAppTest):
 
     def get_inputs(self):
         return {
-            'host_ip': self.public_ip_address,
+            'host_ip': self.private_ip_address,
             'agent_user': 'ubuntu',
             # default agent key location
             'agent_private_key_path': '~/.ssh/agent_key.pem'


### PR DESCRIPTION
Opened port 8086 since the test assertions require it. 
Using private ip as input for single host nodecellar.