### PR TITLE
manager_after_reboot_test now runs only on the datacenter suite and c…

### DIFF
--- a/cosmo_tester/test_suites/test_blueprints/manager_after_reboot_test.py
+++ b/cosmo_tester/test_suites/test_blueprints/manager_after_reboot_test.py
@@ -61,12 +61,12 @@ class ManagerAfterRebootTest(hello_world_bash_test.AbstractHelloWorldTest):
         manager_keypath = self.env._config_reader.management_key_path
         fabric_env = fabric.api.env
         self.logger.info('Fabric env: user={0}, key={1}, host={2}'.format(
-            self.env.centos_image_user,
+            self.env.centos_7_image_user,
             manager_keypath,
             self.env.management_ip))
         fabric_env.update({
             'timeout': 30,
-            'user': self.env.centos_image_user,
+            'user': self.env.centos_7_image_user,
             'key_filename': manager_keypath,
             'host_string': self.env.management_ip,
         })

--- a/cosmo_tester/test_suites/test_manager_status/manager_service_test.py
+++ b/cosmo_tester/test_suites/test_manager_status/manager_service_test.py
@@ -15,21 +15,24 @@
 import urllib
 from time import sleep, time
 
-from fabric.api import env, reboot
+import fabric.api
 
 from cosmo_tester.framework.testenv import TestCase
 from cosmo_tester.framework.util import get_actual_keypath
 
 
 class RebootManagerTest(TestCase):
+
     def _reboot_server(self):
-        env.update({
-            'user': self.env.management_user_name,
+        fabric_env = fabric.api.env
+        fabric_env.update({
+            'timeout': 30,
+            'user': self.env.centos_7_image_user,
             'key_filename': get_actual_keypath(self.env,
                                                self.env.management_key_path),
             'host_string': self.env.management_ip,
-        })
-        reboot()
+            })
+        return fabric.api.run('sudo shutdown -r +1')
 
     def _get_undefined_services(self):
         return [each['display_name']

--- a/suites/suites/suites.yaml
+++ b/suites/suites/suites.yaml
@@ -675,7 +675,7 @@ tests:
 
   openstack_blueprints_without_chef_puppet_docker_windows:
     tests:
-      - cosmo_tester/test_suites/test_blueprints -e puppet -e chef -e docker -e windows
+      - cosmo_tester/test_suites/test_blueprints -e puppet -e chef -e docker -e windows -e test_manager_after_reboot
 
   manager_after_reboot:
     tests:


### PR DESCRIPTION
…hanged reboot impl