### PR TITLE
need to have a centos7 ami avialable in test context

### DIFF
--- a/suites/suites/suites.yaml
+++ b/suites/suites/suites.yaml
@@ -386,6 +386,7 @@ handler_properties:
 
   aws_ec2:
     ubuntu_trusty_image_id: '{{aws_ec2_eu_central_1_ami_ubuntu_trusty_image_id}}'
+    centos_7_image_id: '{{aws_ec2_eu_central_1_ami_centos_7_image_id}}'
     medium_instance_type: '{{aws_ec2_medium_instance_type}}'
     micro_instance_type: '{{aws_ec2_micro_instance_type}}'
 


### PR DESCRIPTION
added
it's used in this: https://github.com/cloudify-cosmo/cloudify-aws-plugin/blob/CFY-4154-Add-Cloud-Init-Agent-Installation/system_tests/manager/aws_ec2_user_data_agent_install_test.py#L60