### PR TITLE
CFY-2834 neutron galore test now checks for security group descriptio…

### DIFF
--- a/cosmo_tester/resources/blueprints/neutron-galore/blueprint.yaml
+++ b/cosmo_tester/resources/blueprints/neutron-galore/blueprint.yaml
@@ -104,6 +104,7 @@ node_templates:
         properties:
             security_group:
                 name: neutron_test_security_group_src
+            description: source security group
     security_group_dst:
         type: cloudify.openstack.nodes.SecurityGroup
         properties:

--- a/cosmo_tester/test_suites/test_blueprints/neutron_galore_test.py
+++ b/cosmo_tester/test_suites/test_blueprints/neutron_galore_test.py
@@ -121,6 +121,8 @@ class NeutronGaloreTest(TestCase):
         self.assertEqual(openstack['router']['name'], p('neutron_router_test'))
         self.assertEqual(openstack['sg_src']['name'],
                          p('neutron_test_security_group_src'))
+        self.assertEqual(openstack['sg_src']['description'],
+                         'source security group')
         self.assertIn(sg_dst_id, port_security_groups)
         self.assertIn(sg_src_id, port_security_groups)
         self.assertEqual(openstack['network']['name'],

--- a/suites/suites/suites.yaml
+++ b/suites/suites/suites.yaml
@@ -218,6 +218,11 @@ templates:
 
   #######################################################
 
+  - &install_python_compilers_input_override
+    install_python_compilers: 'true'
+
+  #######################################################
+
   - &lab_openstack_credentials_inputs
     keystone_username: '{{system_tests_lab_os_username}}'
     keystone_password: '{{system_tests_lab_os_password}}'


### PR DESCRIPTION
…n property too; added install_python_compilers inputs override in suites.yaml