### PR TITLE
CFY-4417 Allow concurrent system tests execution

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -13,7 +13,8 @@ checkout:
 
 dependencies:
   override:
-    - pip install flake8
+    - pip install setuptools --upgrade
+    - pip install flake8 --upgrade
     - pip install -r test-requirements.txt
     - pip install .
 

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
         'Jinja2==2.7.2',
         'influxdb==0.1.13',
         'pywinrm==0.0.3',
+        'fasteners==0.13.0',
         # Wagon version has been left out since it better reflects the user
         # use-case
         'wagon'

--- a/suites/Vagrantfile.template
+++ b/suites/Vagrantfile.template
@@ -3,6 +3,7 @@ ENV['VAGRANT_DEFAULT_PROVIDER'] = 'docker'
 
 def vagrant_configure
   suite_name = '{{suite_name}}'
+  container_name = '{{container_name}}'
   suite = '{{suite}}'
   variables = '{{variables}}'
 
@@ -13,7 +14,7 @@ def vagrant_configure
     end
     config.vm.define suite_name do |container|
       container.vm.provider 'docker' do |d|
-        d.name = suite_name
+        d.name = container_name
         d.env = {
           'TEST_SUITE_NAME' => suite_name,
           'TEST_SUITE' => suite,

--- a/suites/helpers/__init__.py
+++ b/suites/helpers/__init__.py
@@ -1,3 +1,18 @@
+########
+# Copyright (c) 2014 GigaSpaces Technologies Ltd. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import sys
 
 

--- a/suites/helpers/password_store.py
+++ b/suites/helpers/password_store.py
@@ -1,3 +1,18 @@
+########
+# Copyright (c) 2016 GigaSpaces Technologies Ltd. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os
 import shutil
 import tempfile

--- a/suites/helpers/suites_builder.py
+++ b/suites/helpers/suites_builder.py
@@ -1,33 +1,37 @@
+########
+# Copyright (c) 2014 GigaSpaces Technologies Ltd. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import tempfile
-import logging
 
 import yaml
-
-logger = logging.getLogger('suites_builder')
-logger.setLevel(logging.INFO)
 
 
 def build_suites_yaml(all_suites_yaml_path,
                       variables_path,
                       descriptor):
-
-    logger.info('Generating suites yaml:\n'
-                '\descriptor={}'.format(descriptor))
-
     with open(variables_path) as f:
         variables = yaml.load(f.read())
     with open(all_suites_yaml_path) as f:
         suites_yaml = yaml.load(f.read())
     suites_yaml_path = tempfile.mktemp(prefix='suites-', suffix='.json')
-
     test_suites = parse_descriptor(suites_yaml, descriptor)
-
     suites_yaml['variables'] = suites_yaml.get('variables', {})
     suites_yaml['variables'].update(variables)
     suites_yaml['test_suites'] = test_suites
     with open(suites_yaml_path, 'w') as f:
         f.write(yaml.safe_dump(suites_yaml))
-
     return suites_yaml_path
 
 
@@ -54,7 +58,5 @@ def parse_descriptor(suites_yaml, custom_descriptor):
         else:
             suite_id = suite_descriptor
             result[suite_id] = preconfigured[suite_descriptor]
-
         result[suite_id]['descriptor'] = suite_descriptor
-
     return result

--- a/suites/helpers/variables_builder.py
+++ b/suites/helpers/variables_builder.py
@@ -1,3 +1,18 @@
+########
+# Copyright (c) 2016 GigaSpaces Technologies Ltd. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os
 import argparse
 
@@ -46,7 +61,6 @@ def main():
     variables.update(pass_vars)
     with open(os.path.expanduser(args.variables_output_path), 'w') as f:
         f.write(yaml.safe_dump(variables))
-
 
 if __name__ == '__main__':
     main()

--- a/suites/requirements.txt
+++ b/suites/requirements.txt
@@ -5,3 +5,4 @@ nose
 xmltodict
 requests==2.7.0
 jinja2==2.7.2
+fasteners==0.13.0

--- a/suites/suites_runner.py
+++ b/suites/suites_runner.py
@@ -15,13 +15,16 @@
 
 import os
 import sys
+import signal
 import logging
 import json
 import random
 import shutil
 import time
 import tempfile
+from contextlib import contextmanager
 
+import fasteners
 import jinja2
 import yaml
 import sh
@@ -36,8 +39,14 @@ logging.basicConfig()
 logger = logging.getLogger('suites_runner')
 logger.setLevel(logging.INFO)
 
-docker = None
-vagrant = None
+try:
+    docker = sh_bake(sh.docker)
+except sh.CommandNotFound:
+    docker = None
+try:
+    vagrant = sh_bake(sh.vagrant)
+except sh.CommandNotFound:
+    vagrant = None
 
 reports_dir = path(__file__).dirname() / 'xunit-reports'
 
@@ -51,6 +60,7 @@ SCHEDULER_INTERVAL = 30
 class TestSuite(object):
     def __init__(self, suite_name, suite_def, suite_work_dir, variables):
         self.suite_name = suite_name
+        self.container_name = '{0}_{1}'.format(os.getpid(), self.suite_name)
         self.suite_def = suite_def
         self.suite_work_dir = suite_work_dir
         self.suite_reports_dir = suite_work_dir / 'xunit-reports'
@@ -60,6 +70,8 @@ class TestSuite(object):
         self.started = None
         self.terminated = None
         self.timed_out = False
+        self.failed = False
+        self.exit_code = None
 
     @property
     def descriptor(self):
@@ -93,6 +105,7 @@ class TestSuite(object):
         vagrant_file_template = path('Vagrantfile.template').text()
         vagrant_file_content = jinja2.Template(vagrant_file_template).render({
             'suite_name': self.suite_name,
+            'container_name': self.container_name,
             'suite': json.dumps(self.suite_def),
             'variables': json.dumps(self.variables)
         })
@@ -134,9 +147,72 @@ class TestSuite(object):
             os.chdir(cwd)
 
     def terminate(self):
-        logger.info('Stopping docker container: {0}'.format(self.suite_name))
-        docker.stop(self.suite_name).wait()
-        logger.info('Docker container stopped: {0}'.format(self.suite_name))
+        logger.warn('Terminating suite: {0}'.format(self.suite_name))
+        try:
+            logger.info('Stopping docker container: {0}'.format(
+                self.container_name))
+            docker.stop(self.container_name).wait()
+            logger.info('Docker container stopped: {0}'.format(
+                self.container_name))
+        except Exception as e:
+            logger.error('Error on suite termination [suite={0}, error'
+                         '={1}]'.format(self.suite_name, str(e)))
+
+    def kill(self):
+        try:
+            kill_container(self.container_name)
+        except Exception as e:
+            logger.error('Error on suite kill [suite={0}, error'
+                         '={1}]'.format(self.container_name, str(e)))
+
+    @staticmethod
+    def after_suite(suite):
+        # timeout out, need to terminate
+        if suite.timed_out:
+            suite.terminate()
+        else:
+            suite.exit_code = int(
+                sh.docker.wait(suite.container_name).strip())
+            if suite.exit_code:
+                suite.failed = True
+        suite.copy_xunit_reports()
+        # kill removes the container so it should be called after exit code
+        # is extracted and xunit reports are generated
+        suite.kill()
+
+    def copy_xunit_reports(self):
+        report_files = self.suite_reports_dir.files('*.xml')
+        if self.timed_out:
+            self._generate_custom_xunit_report(
+                'Suite {0} timed out after {1} seconds.'.format(
+                        self.descriptor, self.running_time),
+                error_type='TestSuiteTimeout',
+                error_message='Test suite timed out')
+        elif not report_files:
+            self._generate_custom_xunit_report(
+                'Suite {0} has encountered an error before tests ran.'.format(
+                        self.descriptor),
+                error_type='TestSuiteSkipped',
+                error_message='Test suite skipped')
+        else:
+            import lxml.etree as et
+            logger.info('Suite [{0}] reports: {1}'.format(
+                    self.suite_name, [r.name for r in report_files]))
+            # adding suite name as a prefix to each test in each report
+            parser = et.XMLParser(strip_cdata=False)
+            for report in report_files:
+                root = et.parse(report.realpath(), parser)
+                test_elements = root.findall('testcase')
+                for test in test_elements:
+                    test_name = test.get('name')
+                    test.set('name', '{0} @ {1}'.format(test_name,
+                                                        self.suite_name))
+                tmp_file = tempfile.NamedTemporaryFile()
+                tmp_file.write(et.tostring(root, pretty_print=True))
+                # flushing remaining text in buffer before closing the file
+                tmp_file.flush()
+                shutil.copy(tmp_file.name, reports_dir / report.name)
+                tmp_file.close()
 
     def _generate_custom_xunit_report(self,
                                       text,
@@ -144,10 +220,10 @@ class TestSuite(object):
                                       error_message,
                                       fetch_logs=True):
         logger.info('Getting docker logs for container: {0}'.format(
-            self.suite_name))
+            self.container_name))
         if fetch_logs:
             logs = xunit.xml_safe(sh.docker.logs(
-                self.suite_name, _err_to_out=True).strip())
+                self.container_name, _err_to_out=True).strip())
         else:
             logs = ''
         if self._handler_configuration_def:
@@ -187,49 +263,72 @@ Handler configuration:
             report_file.abspath()))
         report_file.write_text(xunit_file_content, encoding='utf-8')
 
-    def copy_xunit_reports(self):
-        report_files = self.suite_reports_dir.files('*.xml')
 
-        if self.timed_out:
-            self._generate_custom_xunit_report(
-                'Suite {0} timed out after {1} seconds.'.format(
-                    self.descriptor, self.running_time),
-                error_type='TestSuiteTimeout',
-                error_message='Test suite timed out')
-        elif not self.started:
-            self._generate_custom_xunit_report(
-                "Suite {0} skipped (couldn't find a matching "
-                "environment).".format(self.descriptor),
-                error_type='TestSuiteSkipped',
-                error_message='Test suite skipped',
-                fetch_logs=False)
-        elif not report_files:
-            self._generate_custom_xunit_report(
-                'Suite {0} has errored before tests ran.'.format(
-                    self.descriptor),
-                error_type='TestSuiteSkipped',
-                error_message='Test suite skipped')
-        else:
-            import lxml.etree as et
+class Environments(object):
 
-            logger.info('Suite [{0}] reports: {1}'.format(
-                self.suite_name, [r.name for r in report_files]))
+    def lock(self, env_id):
+        raise NotImplementedError()
 
-            # adding suite name as a prefix to each test in each report
-            parser = et.XMLParser(strip_cdata=False)
-            for report in report_files:
-                root = et.parse(report.realpath(), parser)
-                test_elements = root.findall('testcase')
-                for test in test_elements:
-                    test_name = test.get('name')
-                    test.set('name', '{0} @ {1}'.format(test_name,
-                                                        self.suite_name))
-                tmp_file = tempfile.NamedTemporaryFile()
-                tmp_file.write(et.tostring(root, pretty_print=True))
-                # flushing remaining text in buffer before closing the file
-                tmp_file.flush()
-                shutil.copy(tmp_file.name, reports_dir / report.name)
-                tmp_file.close()
+    def release(self, env_id):
+        raise NotImplementedError()
+
+    def prune(self, include_self=False):
+        pass
+
+
+class InMemoryEnvironments(Environments):
+
+    def __init__(self):
+        self._locked_envs = set()
+
+    def lock(self, env_id):
+        if env_id in self._locked_envs:
+            return False
+        self._locked_envs.add(env_id)
+        return True
+
+    def release(self, env_id):
+        self._locked_envs.remove(env_id)
+
+
+class FileEnvironments(Environments):
+
+    def __init__(self, locked_environments_path):
+        self._locked_environments_path = locked_environments_path
+        self._locked_environments_lock = fasteners.InterProcessLock(
+            '{}.lock'.format(locked_environments_path))
+
+    def lock(self, env_id):
+        with self._update() as locked_environments:
+            if env_id in locked_environments:
+                return False
+            locked_environments[env_id] = os.getpid()
+            return True
+
+    def release(self, env_id):
+        with self._update() as locked_environments:
+            del locked_environments[env_id]
+
+    def prune(self, include_self=False):
+        with self._update() as locked_environments:
+            current_pid = os.getpid()
+            for k in locked_environments.keys():
+                pid = locked_environments[k]
+                if ((include_self and current_pid == pid) or
+                        not is_pid_of_suites_runner(pid)):
+                    del locked_environments[k]
+
+    @contextmanager
+    def _update(self):
+        with self._locked_environments_lock:
+            if os.path.exists(self._locked_environments_path):
+                with open(self._locked_environments_path, 'r') as f:
+                    locked_environments = json.load(f)
+            else:
+                locked_environments = {}
+            yield locked_environments
+            with open(self._locked_environments_path, 'w') as f:
+                json.dump(locked_environments, f)
 
 
 class SuitesScheduler(object):
@@ -239,20 +338,22 @@ class SuitesScheduler(object):
                  scheduling_interval=1,
                  optimize=False,
                  after_suite_callback=None,
-                 suite_timeout=-1):
+                 suite_timeout=-1,
+                 environments=None):
         self._test_suites = test_suites
         if optimize:
             self._test_suites = sorted(
                 test_suites,
                 key=lambda x: x.handler_configuration is None)
         self._handler_configurations = handler_configurations
-        self._locked_envs = set()
+        self._environments = environments or InMemoryEnvironments()
         self._scheduling_interval = scheduling_interval
         self._after_suite_callback = after_suite_callback
         self._suite_timeout = suite_timeout
         self._validate()
         self._log_test_suites()
-        self.skipped_suites = []
+        self.timed_out_suites = []
+        self.failed_suites = []
 
     def _log_test_suites(self):
         output = {x.suite_name: x.suite_def for x in self._test_suites}
@@ -281,44 +382,40 @@ class SuitesScheduler(object):
                 # Run suite
                 if not suite.started:
                     matches = self._find_matching_handler_configurations(suite)
-                    if not matches:
-                        logger.warn(
-                            'Suite: {0} has no matching handler configuration.'
-                            ' Suite will be skipped.'.format(suite.suite_name))
-                        self._after_suite(suite)
-                        self.skipped_suites.append(suite)
-                    else:
-                        config_names = matches.keys()
-                        random.shuffle(config_names)
-                        logger.info(
-                            'Matching handler configurations for {0} are: {1}'
-                            .format(suite.suite_name, ', '.join(config_names)))
-                        for name in config_names:
-                            configuration = matches[name]
-                            if self._lock_env(configuration['env']):
-                                suite.handler_configuration = (name,
-                                                               configuration)
-                                suite.started = time.time()
-                                suite.run()
-                                break
-                        if suite.started:
-                            logger.info('Suite {0} will run using handler '
-                                        'configuration: {1}'.format(
-                                            suite.suite_name,
-                                            suite.handler_configuration))
-                        else:
+                    config_names = matches.keys()
+                    random.shuffle(config_names)
+                    logger.info(
+                        'Matching handler configurations for {0} are: {1}'
+                        .format(suite.suite_name, ', '.join(config_names)))
+                    for name in config_names:
+                        configuration = matches[name]
+                        if self._environments.lock(configuration['env']):
+                            suite.handler_configuration = (name,
+                                                           configuration)
+                            suite.started = time.time()
                             logger.info(
-                                'All matching handler configurations for {0} '
-                                'are currently taken'.format(suite.suite_name))
-                        remaining_suites.append(suite)
+                                'Suite {0} will run using handler '
+                                'configuration: {1}'.format(
+                                        suite.suite_name,
+                                        suite.handler_configuration))
+                            suite.run()
+                            break
+                    else:
+                        logger.info(
+                            'All matching handler configurations for {0} '
+                            'are currently taken'.format(suite.suite_name))
+                    remaining_suites.append(suite)
                 # Suite terminated
                 elif not suite.is_running:
                     logger.info(
                         'Suite terminated: {0}'.format(suite.suite_name))
                     self._after_suite(suite)
+                    if suite.failed:
+                        self.failed_suites.append(suite)
                 # Suite timed out
                 elif self._suite_timeout != -1 \
                         and suite.running_time > self._suite_timeout:
+                    self.timed_out_suites.append(suite)
                     suite.timed_out = True
                     config = self._handler_configurations[
                         suite.handler_configuration]
@@ -328,16 +425,7 @@ class SuitesScheduler(object):
                             suite.suite_name,
                             config,
                             int(suite.running_time)))
-                    logger.warn(
-                        'Terminating suite: {0}'.format(suite.suite_name))
-                    try:
-                        suite.terminate()
-                    except Exception as e:
-                        logger.error(
-                            'Error on suite termination [suite={0}, error'
-                            '={1}]'.format(suite.suite_name, str(e)))
                     self._after_suite(suite)
-                    self._remove_env(config['env'])
                 # Suite is running
                 else:
                     remaining_suites.append(suite)
@@ -345,26 +433,8 @@ class SuitesScheduler(object):
             time.sleep(self._scheduling_interval)
         logger.info('Test suites scheduler stopped')
 
-    def _remove_env(self, env_id):
-        logger.warn(
-            'Removing all handler configurations which use '
-            'env: {0}'.format(env_id))
-        for k in self._handler_configurations.keys():
-            config = self._handler_configurations[k]
-            if config['env'] == env_id:
-                logger.warn(
-                    'Removing handler configuration: {0} '
-                    '[env_id={1}]'.format(k, env_id))
-                del self._handler_configurations[k]
-
     def _after_suite(self, suite):
-        if suite.started:
-            suite.terminated = time.time()
-        if suite.handler_configuration:
-            config = self._handler_configurations.get(
-                suite.handler_configuration)
-            if config:
-                self._release_env(config['env'])
+        suite.terminated = time.time()
         try:
             if self._after_suite_callback:
                 logger.info(
@@ -375,6 +445,9 @@ class SuitesScheduler(object):
             logger.error(
                 'After suite callback failed for suite: {0} - '
                 'error: {1}'.format(suite.suite_name, str(e)))
+        config = self._handler_configurations.get(suite.handler_configuration)
+        if config:
+            self._environments.release(config['env'])
 
     def _find_matching_handler_configurations(self, suite):
         if suite.handler_configuration:
@@ -393,168 +466,159 @@ class SuitesScheduler(object):
             if tags_match(suite.requires, v.get('tags', set()))
         }
 
-    def _lock_env(self, env_id):
-        if env_id in self._locked_envs:
-            return False
-        self._locked_envs.add(env_id)
-        return True
 
-    def _release_env(self, env_id):
-        self._locked_envs.remove(env_id)
+class SuitesRunner(object):
+
+    def __init__(self, variables_path, descriptor):
+        self.descriptor = descriptor
+        self.variables_path = variables_path
+        self.suites_yaml = None
+        self.envs_dir = path.getcwd() / SUITE_ENVS_DIR
+
+    def setenv(self):
+        if os.path.exists(self.envs_dir):
+            shutil.rmtree(self.envs_dir)
+
+        if not reports_dir.exists():
+            reports_dir.mkdir()
+        for report in reports_dir.files():
+            report.remove()
+
+        logger.info('Generating suites yaml:\n'
+                    '\descriptor={}'.format(self.descriptor))
+        test_suites_path = build_suites_yaml('suites/suites.yaml',
+                                             self.variables_path,
+                                             self.descriptor)
+        os.environ[TEST_SUITES_PATH] = test_suites_path
+        with open(test_suites_path) as f:
+            self.suites_yaml = yaml.safe_load(f)
+
+    def validate(self):
+        for suite_name, suite in self.suites_yaml['test_suites'].items():
+            requires = suite.get('requires')
+            configuration_name = suite.get('handler_configuration')
+            if requires and configuration_name:
+                raise AssertionError(
+                    'Suite: {0} has both "requires" and '
+                    '"handler_configuration" set'.format(suite_name))
+            elif not requires and not configuration_name:
+                raise AssertionError(
+                    'Suite: {0} does not have "requires" or '
+                    '""handler_configuration" specified'.format(suite_name))
+        for name, configuration in self.suites_yaml[
+                'handler_configurations'].iteritems():
+            if 'env' not in configuration:
+                raise AssertionError(
+                    '"{0}" handler configuration does not contain an env '
+                    'property'.format(name))
+
+    def run_suites(self):
+        self.build_docker_image()
+        variables = self.suites_yaml.get('variables', {})
+        test_suites = [
+            TestSuite(suite_name=suite_name,
+                      suite_def=suite_def,
+                      suite_work_dir=self.envs_dir / suite_name,
+                      variables=variables) for suite_name, suite_def in
+            self.suites_yaml['test_suites'].iteritems()]
+        environments_path = os.path.join(sys.prefix, 'environments.json')
+        environments = FileEnvironments(
+            locked_environments_path=environments_path)
+        logger.info('Pruning environments before suites run')
+        environments.prune()
+
+        def sigterm_handler(num, frame):
+            logger.info('Pruning environments on sigterm')
+            environments.prune(include_self=True)
+            logger.info('Pruning containers on sigterm')
+            self.prune_containers(include_self=True)
+            sys.exit(1)
+        signal.signal(signal.SIGTERM, sigterm_handler)
+
+        scheduler = SuitesScheduler(
+            test_suites=test_suites,
+            handler_configurations=self.suites_yaml['handler_configurations'],
+            scheduling_interval=SCHEDULER_INTERVAL,
+            optimize=True,
+            after_suite_callback=TestSuite.after_suite,
+            suite_timeout=60 * 60 * 5,
+            environments=environments)
+        scheduler.run()
+        if scheduler.failed_suites or scheduler.timed_out_suites:
+            logger.warn('Failed test suites: {0}'.format(
+                ''.join(['\n\t{0} (exit_code: {1})'.format(x.suite_name,
+                                                           x.exit_code)
+                        for x in scheduler.failed_suites])))
+            logger.warn('Timed out test suites: {0}'.format(
+                ''.join(['\n\t{0}'.format(x.suite_name)
+                         for x in scheduler.timed_out_suites])))
+            sys.exit(1)
+
+    @staticmethod
+    def prune_containers(include_self=False):
+        container_ids = sh.docker.ps(a=True, q=True).stdout.strip()
+        container_ids = [c.strip() for c in container_ids.split(os.linesep)
+                         if c.strip()]
+        for container_id in container_ids:
+            container_name = sh.docker.ps(filter='id={0}'.format(container_id),
+                                          format='{{.Names}}').stdout.strip()
+            split_container_name = container_name.split('_', 1)
+            if len(split_container_name) < 2:
+                continue
+            try:
+                pid = int(split_container_name[0])
+            except ValueError:
+                continue
+            current_pid = os.getpid()
+            if ((include_self and pid == current_pid) or
+                    not is_pid_of_suites_runner(pid)):
+                kill_container(container_id)
+
+    def build_docker_image(self):
+        docker.build(
+                ['-t',
+                 '{0}:{1}'.format(DOCKER_REPOSITORY, DOCKER_TAG), '.']).wait()
+        docker_image_id = self._get_docker_image_id()
+        if not docker_image_id:
+            raise RuntimeError(
+                    'Docker image not found after docker image was built.')
+
+    @staticmethod
+    def _get_docker_image_id():
+        image_ids = [line for line in sh.docker.images(
+                ['-q', DOCKER_REPOSITORY]).strip().split(os.linesep)
+                 if len(line) > 0]
+        if len(image_ids) > 1:
+            raise RuntimeError(
+                    'Found several docker image ids instead of a single one.')
+        return image_ids[0] if image_ids else None
 
 
-def list_containers(quiet=False):
-    return sh.docker.ps(a=True, q=quiet).strip()
-
-
-def get_docker_image_id():
-    image_ids = [line for line in sh.docker.images(
-        ['-q', DOCKER_REPOSITORY]).strip().split(os.linesep) if len(line) > 0]
-    if len(image_ids) > 1:
-        raise RuntimeError(
-            'Found several docker image ids instead of a single one.')
-    return image_ids[0] if image_ids else None
-
-
-def build_docker_image():
-    docker.build(
-        ['-t',
-         '{0}:{1}'.format(DOCKER_REPOSITORY, DOCKER_TAG), '.']).wait()
-    docker_image_id = get_docker_image_id()
-    if not docker_image_id:
-        raise RuntimeError(
-            'Docker image not found after docker image was built.')
-
-
-def kill_containers():
-    containers = list_containers(quiet=True).replace(os.linesep, ' ')
-    containers = [c.strip() for c in containers.split(' ') if c.strip()]
-    if containers:
-        logger.info('Killing containers: {0}'.format(containers))
-        docker.rm('-f', *containers).wait()
-
-
-def container_exit_code(container_name):
-    return int(sh.docker.wait(container_name).strip())
-
-
-def container_kill(container_name):
+def kill_container(container_name):
     logger.info('Killing container: {0}'.format(container_name))
     docker.rm('-f', container_name).wait()
 
 
-def copy_xunit_report(suite):
-    suite.copy_xunit_reports()
-
-
-def test_start():
-    if os.path.exists(SUITE_ENVS_DIR):
-        shutil.rmtree(SUITE_ENVS_DIR)
-
-    with open(os.environ[TEST_SUITES_PATH]) as f:
-        suites_yaml = yaml.load(f.read())
-    variables = suites_yaml.get('variables', {})
-
-    build_docker_image()
-
-    envs_dir = path.getcwd() / SUITE_ENVS_DIR
-
-    test_suites = [
-        TestSuite(suite_name,
-                  suite_def,
-                  envs_dir / suite_name,
-                  variables) for suite_name, suite_def in
-        suites_yaml['test_suites'].iteritems()]
-
-    scheduler = SuitesScheduler(test_suites,
-                                suites_yaml['handler_configurations'],
-                                scheduling_interval=SCHEDULER_INTERVAL,
-                                optimize=True,
-                                after_suite_callback=copy_xunit_report,
-                                suite_timeout=60 * 60 * 5)
-    scheduler.run()
-    return scheduler
-
-
-def test_run():
-    scheduler = test_start()
-    logger.info('wait for containers exit status codes')
-    containers = [x for x in get_containers_names()
-                  if x not in scheduler.skipped_suites]
-    exit_codes = [(c, container_exit_code(c)) for c in containers]
-    logger.info('removing containers')
-    for c in containers:
-        container_kill(c)
-    failed_containers = [(c, exit_code)
-                         for c, exit_code in exit_codes
-                         if exit_code != 0]
-    if failed_containers or scheduler.skipped_suites:
-        logger.warn('Failed test suites:')
-        for c, exit_code in failed_containers:
-            logger.warn('\t{}: exit code: {}'.format(c, exit_code))
-        logger.warn('Skipped test suites: {0}'.format(
-            x.suite_name for x in scheduler.skipped_suites))
-        sys.exit(1)
-
-
-def setenv(variables_path):
-    setup_reports_dir()
-    descriptor = os.environ['SYSTEM_TESTS_DESCRIPTOR']
-    os.environ[TEST_SUITES_PATH] = build_suites_yaml('suites/suites.yaml',
-                                                     variables_path,
-                                                     descriptor)
-
-
-def validate():
-    with open(os.environ[TEST_SUITES_PATH]) as f:
-        suites = yaml.load(f.read())
-    for suite_name, suite in suites['test_suites'].items():
-        requires = suite.get('requires')
-        configuration_name = suite.get('handler_configuration')
-        if requires and configuration_name:
-            raise AssertionError(
-                'Suite: {0} has both "requires" and "handler_configuration" '
-                'set'.format(suite_name))
-        elif not requires and not configuration_name:
-            raise AssertionError(
-                'Suite: {0} does not have "requires" or '
-                '""handler_configuration" specified'.format(suite_name))
-    for name, configuration in suites['handler_configurations'].iteritems():
-        if 'env' not in configuration:
-            raise AssertionError(
-                '"{0}" handler configuration does not contain an env '
-                'property'.format(name))
-
-
-def cleanup():
-    logger.info('Current containers:\n{0}'
-                .format(list_containers()))
-    kill_containers()
-
-
-def setup_reports_dir():
-    if not reports_dir.exists():
-        reports_dir.mkdir()
-    for report in reports_dir.files():
-        report.remove()
-
-
-def get_containers_names():
-    with open(os.environ[TEST_SUITES_PATH]) as f:
-        suites = yaml.load(f.read())['test_suites'].keys()
-    return [s for s in suites]
+def is_pid_of_suites_runner(pid):
+    try:
+        os.kill(int(pid), 0)
+    except (ValueError, OSError):
+        return False
+    try:
+        cmd = sh.ps('h', p=str(pid), o='cmd').stdout.strip()
+        return 'suites_runner' in cmd
+    except sh.ErrorReturnCode:
+        return False
 
 
 def main():
-    variables_path = sys.argv[1]
-    global docker, vagrant
-    docker = sh_bake(sh.docker)
-    vagrant = sh_bake(sh.vagrant)
-    setenv(variables_path)
-    cleanup()
-    validate()
-    test_run()
-
+    suites_runner = SuitesRunner(variables_path=sys.argv[1],
+                                 descriptor=sys.argv[2])
+    suites_runner.setenv()
+    suites_runner.validate()
+    logger.info('Pruning containers before suites run')
+    suites_runner.prune_containers()
+    suites_runner.run_suites()
 
 if __name__ == '__main__':
     main()

--- a/suites/suites_runner.sh
+++ b/suites/suites_runner.sh
@@ -22,14 +22,14 @@ create_virtualenv_if_needed_and_source()
 
 suites_runner()
 {
-    local variables_yaml_path=$(mktemp -t vars-XXXXXXXX)
+    local variables_yaml_path="$(mktemp -t vars-XXXXXXXX)"
     echo "Writing variables to ${variables_yaml_path}"
     python helpers/variables_builder.py \
-        --variables-output-path=${variables_yaml_path} \
-        --jenkins-parameters-path=${EXPORT_PARAMS_FILE} \
-        --gpg-secret-key-path=${SYSTEM_TESTS_SECRET_KEY_PATH}
-    rm ${SYSTEM_TESTS_SECRET_KEY_PATH}
-    python suites_runner.py ${variables_yaml_path}
+        --variables-output-path="${variables_yaml_path}" \
+        --jenkins-parameters-path="${EXPORT_PARAMS_FILE}" \
+        --gpg-secret-key-path="${SYSTEM_TESTS_SECRET_KEY_PATH}"
+    rm "${SYSTEM_TESTS_SECRET_KEY_PATH}"
+    exec python suites_runner.py "${variables_yaml_path}" "${SYSTEM_TESTS_DESCRIPTOR}"
 }
 
 main()

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,3 +3,4 @@ git+https://github.com/cloudify-cosmo/cloudify-rest-client@master#egg=cloudify-r
 git+https://github.com/cloudify-cosmo/cloudify-plugins-common@master#egg=cloudify-plugins-common==3.4a2
 git+https://github.com/cloudify-cosmo/cloudify-script-plugin@master#egg=cloudify-script-plugin==1.4
 git+https://github.com/cloudify-cosmo/cloudify-cli@master#egg=cloudify==3.4a2
+mock


### PR DESCRIPTION
* Some of the changes in this PR are just refactoring.
* There is no longer a concept of skipped suites. It used to exist before we added the `clean_all` to handlers. Now, if a suite times out, other suites that need that environment can still use it because they will cleanup before. This is why `remove_env`
was also removed in this PR.
* Refactored the lock env and release env concepts so that different implementations can be provided. Previous implementation is now named `InMemoryEnvironments` and it is currently only used in unit tests. New `FileEnvironments` implementation makes use of a shared (lock protected) file and is suitable for use on a single jenkins slave by multiple processes. The current path chosen to store this file is the root of the virtualenv that is shared by system tests executions. It is named `environments.json`.
* Locked environments are pruned by before suites execution starts. Pruning is based on PIDs of `suites_runner.py` processes. If an environment is attached to a certain PID and that PID does not exist or is not a `suites_runner.py` process, this environment is pruned and can be used again.
* Containers are also pruned before each suites execution starts, using a similar PID based method, the container names now start with a PID prefix of the `suites_runner.py` process that started them. (e.g. `21231_ec2_tests`)
* Added a `SIGTERM` handler that prunes environments and containers including those started by the current `suites_runner.py` process. Even though not strictly required, as they will be pruned by the next system tests run, it is cleaner and will stop
containers that are currently creating IaaS resources more quickly. Pressing stop on a jenkins job triggers that `SIGTERM` handler. I think pressing stop more than once will send a `SIGKILL` so that should be avoided I guess, but I did not test this, neither is it mentioned in the jenkins docs (they are only mentioning the `SIGTERM`) (Edit: After reading their code and then the OpenJDK implementation, it seems it will always be `SIGTERM`, so I think it's safe)
* Now using `exec` when running the `suites_runner.py` so that it grabs the `SIGTERM` sent by jenkins. (also updated the jenkins script that calls `suites_runner.sh` to call it with `exec`). Although the jenkins documentation states that it will send `SIGTERM` to all descendant processes, I find this method more robust. (`exec` will replace the current process with the
executed process, the process PID will remain).
* I tried making circle pass as well, but gave up on that.
