### PR TITLE
CFY-4607 cleanup: each test removes keypairs it creates

### DIFF
--- a/cosmo_tester/test_suites/backwards/test_nodecellar_backwards_compatibility/nodecellar_backwards_compatibility_test_base.py
+++ b/cosmo_tester/test_suites/backwards/test_nodecellar_backwards_compatibility/nodecellar_backwards_compatibility_test_base.py
@@ -63,22 +63,21 @@ class NodecellarBackwardsCompatibilityTestBase(TestCase):
                             'mongod security group')
 
     def _bootstrap(self):
+        self.addCleanup(self.cfy.teardown)
         self.cfy.bootstrap(blueprint_path=self.test_manager_blueprint_path,
                            inputs_file=self.test_inputs_path,
                            task_retries=5,
                            install_plugins=self.env.install_plugins)
-        self.addCleanup(self.cfy.teardown)
 
     def set_rest_client(self):
         self.client = CloudifyClient(host=self.env.management_ip)
 
     def _running_env_setup(self):
-        self.env.management_ip = self.cfy.get_management_ip()
-        self.set_rest_client()
-
         def clean_mgmt_ip():
             self.env.management_ip = None
         self.addCleanup(clean_mgmt_ip)
+        self.env.management_ip = self.cfy.get_management_ip()
+        self.set_rest_client()
 
         response = self.client.manager.get_status()
         if not response['status'] == 'running':

--- a/cosmo_tester/test_suites/test_blueprints/elasticsearch_test.py
+++ b/cosmo_tester/test_suites/test_blueprints/elasticsearch_test.py
@@ -79,6 +79,7 @@ class ElasticsearchTimestampFormatTest(TestCase):
         super(ElasticsearchTimestampFormatTest, self).setUp()
         # addCleanup is always called, tearDown is not called
         # if setUp fails
+        self.elasticsearch_rule = None
         self.addCleanup(self._delete_elasticsearch_rule)
         self._create_elasticsearch_rule()
 

--- a/cosmo_tester/test_suites/test_blueprints/nodecellar_test.py
+++ b/cosmo_tester/test_suites/test_blueprints/nodecellar_test.py
@@ -243,6 +243,12 @@ class NodecellarAppTest(MonitoringTestCase):
 class OpenStackNodeCellarTestBase(NodecellarAppTest):
 
     def _test_openstack_nodecellar(self, blueprint_file):
+
+        self.addCleanup(self.execute_uninstall, deployment_id=self.test_id,
+                        delete_deployment_and_blueprint=True)
+        self.addCleanup(self.env.handler.remove_keypairs_from_manager,
+                        deployment_id=self.test_id)
+
         self._test_nodecellar_impl(blueprint_file)
 
     def get_inputs(self):

--- a/cosmo_tester/test_suites/test_blueprints/test_existing_vm.py
+++ b/cosmo_tester/test_suites/test_blueprints/test_existing_vm.py
@@ -78,17 +78,13 @@ class ExistingVMTest(TestCase):
         self.logger.info('Uninstalling deployment...')
         self.execute_uninstall()
 
-    def delete_keypair(self, nova_client, keypair):
-        self.logger.info('Deleting keypair: {0}'.format(keypair))
-        nova_client.keypairs.delete(keypair)
-
     def create_keypair_and_copy_to_manager(self,
                                            nova_client,
                                            remote_key_path,
                                            key_name):
         key_file = path(self.workdir) / '{}.pem'.format(key_name)
+        self.addCleanup(self.env.handler.remove_keypair, key_name)
         keypair = nova_client.keypairs.create(key_name)
-        self.addCleanup(self.delete_keypair, nova_client, keypair)
 
         key_file.write_text(keypair.private_key)
         key_file.chmod(0600)

--- a/cosmo_tester/test_suites/test_broker_security/broker_security_test_base.py
+++ b/cosmo_tester/test_suites/test_broker_security/broker_security_test_base.py
@@ -76,23 +76,22 @@ class BrokerSecurityTestBase(TestCase):
         return {}
 
     def _bootstrap(self):
+        self.addCleanup(self.cfy.teardown)
         self.cfy.bootstrap(blueprint_path=self.test_manager_blueprint_path,
                            inputs_file=self.test_inputs_path,
                            task_retries=5,
                            install_plugins=self.env.install_plugins)
-        self.addCleanup(self.cfy.teardown)
 
     def set_rest_client(self):
         self.client = CloudifyClient(
             host=self.env.management_ip)
 
     def _running_env_setup(self):
-        self.env.management_ip = self.cfy.get_management_ip()
-        self.set_rest_client()
-
         def clean_mgmt_ip():
             self.env.management_ip = None
         self.addCleanup(clean_mgmt_ip)
+        self.env.management_ip = self.cfy.get_management_ip()
+        self.set_rest_client()
 
         response = self.client.manager.get_status()
         if not response['status'] == 'running':

--- a/cosmo_tester/test_suites/test_external_components/base_external_components.py
+++ b/cosmo_tester/test_suites/test_external_components/base_external_components.py
@@ -34,6 +34,10 @@ class BaseExternalComponentsTest(AbstractHelloWorldTest,
             name=self._testMethodName,
             ignored_modules=cli_constants.IGNORED_LOCAL_WORKFLOW_MODULES)
 
+        self.addCleanup(self.env.handler.remove_keypairs_from_local_env,
+                        self.ext_local_env)
+        self.addCleanup(self.cleanup_ext)
+
         self.logger.info('starting vm to serve as the management vm')
         self.ext_local_env.execute('install',
                                    task_retries=10,
@@ -44,7 +48,6 @@ class BaseExternalComponentsTest(AbstractHelloWorldTest,
         self.external_components_private_ip = \
             self.ext_local_env.outputs()[
                 'external_components_vm_private_ip_address']
-        self.addCleanup(self.cleanup_ext)
 
     def cleanup_ext(self):
         self.ext_local_env.execute('uninstall',

--- a/cosmo_tester/test_suites/test_security/security_test_base.py
+++ b/cosmo_tester/test_suites/test_security/security_test_base.py
@@ -170,11 +170,11 @@ class SecurityTestBase(TestCase):
         return overrides
 
     def _bootstrap(self):
+        self.addCleanup(self.cfy.teardown)
         self.cfy.bootstrap(blueprint_path=self.test_manager_blueprint_path,
                            inputs_file=self.test_inputs_path,
                            task_retries=5,
                            install_plugins=self.env.install_plugins)
-        self.addCleanup(self.cfy.teardown)
 
     def _set_credentials_env_vars(self):
         os.environ[constants.CLOUDIFY_USERNAME_ENV] = self.TEST_CFY_USERNAME
@@ -191,14 +191,14 @@ class SecurityTestBase(TestCase):
                                          password=self.TEST_CFY_PASSWORD))
 
     def _running_env_setup(self):
-        self.env.management_ip = self.cfy.get_management_ip()
-        self.set_rest_client()
 
         def clear_mgmt_and_security_settings():
             self.env.management_ip = None
             self.env.rest_client = None
             self._unset_credentials_env_vars()
         self.addCleanup(clear_mgmt_and_security_settings)
+        self.env.management_ip = self.cfy.get_management_ip()
+        self.set_rest_client()
 
         response = self.client.manager.get_status()
         if not response['status'] == 'running':

--- a/cosmo_tester/test_suites/test_simple_manager_blueprint/abstract_single_host_test.py
+++ b/cosmo_tester/test_suites/test_simple_manager_blueprint/abstract_single_host_test.py
@@ -58,6 +58,10 @@ class AbstractSingleHostTest(object):
             name=self._testMethodName,
             ignored_modules=cli_constants.IGNORED_LOCAL_WORKFLOW_MODULES)
 
+        self.addCleanup(self.uninstall_client)
+        self.addCleanup(self.env.handler.remove_keypairs_from_local_env,
+                        self.local_env)
+
         self.logger.info('starting vm to serve as the management vm')
         self.local_env.execute('install',
                                task_retries=10,
@@ -66,9 +70,6 @@ class AbstractSingleHostTest(object):
             self.local_env.outputs()['simple_vm_public_ip_address']
         self.private_ip_address = \
             self.local_env.outputs()['simple_vm_private_ip_address']
-
-        self.addCleanup(self.clear_management_ip)
-        self.addCleanup(self.uninstall_client)
 
     def bootstrap_simple_manager_blueprint(self, override_inputs=None):
         self.manager_blueprints_repo_dir = clone(MANAGER_BLUEPRINTS_REPO_URL,
@@ -104,12 +105,13 @@ class AbstractSingleHostTest(object):
                            self.remote_manager_key_path)
 
     def _bootstrap(self):
+        self.addCleanup(self.cfy.teardown)
         self.cfy.bootstrap(blueprint_path=self.test_manager_blueprint_path,
                            inputs_file=self.test_inputs_path,
                            task_retries=5)
-        self.addCleanup(self.cfy.teardown)
 
     def _running_env_setup(self, management_ip):
+        self.addCleanup(self.clear_management_ip)
         self.env.management_ip = management_ip
         self.client = create_rest_client(management_ip)
         response = self.client.manager.get_status()

--- a/cosmo_tester/test_suites/test_snapshots/snapshots_migration_from_321_to_33_test.py
+++ b/cosmo_tester/test_suites/test_snapshots/snapshots_migration_from_321_to_33_test.py
@@ -203,14 +203,13 @@ class HelloWorldSnapshotMigrationFrom_3_2_1_To_3_3_Test(TestCase):
                 {'dns_nameservers': ['8.8.4.4', '8.8.8.8']}
             )
 
+        self.addCleanup(self._teardown_manager_3_3)
         self.cfy.bootstrap(
             blueprint_path,
             os.path.join(self.workdir, NEW_MANAGER_INPUTS_NAME),
         )
 
         self.client = create_rest_client(self.cfy.get_management_ip())
-
-        self.addCleanup(self._teardown_manager_3_3)
 
         self._run_code_on_manager_3_3('sudo yum install -y gcc python-devel')
 
@@ -329,14 +328,13 @@ class HelloWorldSnapshotMigrationFrom_3_2_1_To_3_3_Test(TestCase):
             BOOTSTRAP_SCRIPT_NAME
         )
 
+        self.addCleanup(self._teardown_manager_3_2_1)
         rc = self._run_script(BOOTSTRAP_SCRIPT_NAME)
         if rc:
             self.fail(
                 'Bootstrapping manager 3.2.1 failed with exit code: {0}'
                 .format(rc)
             )
-
-        self.addCleanup(self._teardown_manager_3_2_1)
 
     def _teardown_manager_3_2_1(self):
         self.logger.info('Tearing down manager 3.2.1')


### PR DESCRIPTION
Operations that can partially fail, and that need some cleanup
(eg. the install/uninstall workflows) need to have their cleanup
scheduled (using .addCleanup) BEFORE running them.

In case the operation (eg. install) fails partway, and throws an
exception, the .addCleanup call might be skipped because of the
exception, and the uninstall won't run, leaving the system with
a partially-executed workflow that was never cleaned up after.

This change makes sure that all .addCleanup calls are always scheduled
before the risky operation they're cleaning up after.

This also uses the new openstack plugin API for removing keypairs.