### PR TITLE
CFY-5948 Replace base64 encode function

### DIFF
--- a/cosmo_tester/framework/util.py
+++ b/cosmo_tester/framework/util.py
@@ -29,7 +29,7 @@ import tempfile
 import yaml
 import jinja2
 from path import path
-from itsdangerous import base64_encode
+from base64 import urlsafe_b64encode
 from wagon.wagon import Wagon
 
 from cloudify_cli import constants
@@ -217,7 +217,7 @@ def get_auth_header(username=None, password=None, token=None):
     header = {}
     if username and password:
         credentials = '{0}:{1}'.format(username, password)
-        header[CLOUDIFY_AUTHORIZATION_HEADER] = base64_encode(credentials)
+        header[CLOUDIFY_AUTHORIZATION_HEADER] = urlsafe_b64encode(credentials)
     elif token:
         header[CLOUDIFY_AUTH_TOKEN_HEADER] = token
     return header

--- a/cosmo_tester/resources/plugins/mock-auth-provider-with-no-userstore/mock_auth_provider_with_no_userstore/auth_without_userstore.py
+++ b/cosmo_tester/resources/plugins/mock-auth-provider-with-no-userstore/mock_auth_provider_with_no_userstore/auth_without_userstore.py
@@ -13,7 +13,7 @@
 #  * See the License for the specific language governing permissions and
 #  * limitations under the License.
 
-from itsdangerous import base64_decode
+from base64 import urlsafe_b64encode
 from flask import request
 from flask_securest.authentication_providers.abstract_authentication_provider\
     import AbstractAuthenticationProvider
@@ -33,7 +33,7 @@ class AuthorizeUserByUsername(AbstractAuthenticationProvider):
 
         auth_header = auth_header.replace(BASIC_AUTH_PREFIX + ' ', '', 1)
         try:
-            api_key = base64_decode(auth_header)
+            api_key = urlsafe_b64encode(auth_header)
         except TypeError:
             pass
         else:


### PR DESCRIPTION
The old one would remove trailing padding `=`'s, which caused problems for flask-security