### PR TITLE
CFY-6747-Re-enable auto heal checks

### DIFF
--- a/cosmo_tester/test_suites/image_based_tests/auto_heal_test.py
+++ b/cosmo_tester/test_suites/image_based_tests/auto_heal_test.py
@@ -37,7 +37,6 @@ def nodecellar(cfy, manager, attributes, ssh_key, tmpdir, logger):
     nc.cleanup()
 
 
-@pytest.mark.skip(reason='Riemann modifications in progress...')
 def test_nodecellar_auto_healing(cfy, manager, nodecellar, logger):
     nodecellar.clone_example()
 


### PR DESCRIPTION
Only to be merged once riemann changes are done on manager blueprints.