### PR TITLE
CFY-7124 Make the `install_with_sudo` param mandatory

### DIFF
--- a/cosmo_tester/test_suites/image_based_tests/agent_installation_test.py
+++ b/cosmo_tester/test_suites/image_based_tests/agent_installation_test.py
@@ -360,8 +360,8 @@ def install_script(name, windows, user, manager, attributes, tmpdir, logger):
     try:
         current_ctx.set(ctx)
         os.environ.update(env_vars)
-
-        init_script = script.init_script(cloudify_agent={})
+        agent_config = {'install_with_sudo': True}
+        init_script = script.init_script(cloudify_agent=agent_config)
     finally:
         for var_name in list(env_vars):
             os.environ.pop(var_name, None)


### PR DESCRIPTION
This is instead of inferring whether sudo is needed from the install
method.
The only 3 cases that use the `init_script` method are:
1. Regular userdata - in which case sudo is not needed
2. Agents upgrade - in which case the install method would be
   irrelevant in any case, and passing an argument would be necessary
3. System tests/other provided scenarios - in which case it is
   somewhat more flexible (and up to the user) to require providing
   the argument