### PR TITLE
CFY-7099 Support community images for testing

### DIFF
--- a/cosmo_tester/framework/util.py
+++ b/cosmo_tester/framework/util.py
@@ -301,11 +301,29 @@ def get_plugin_wagon_urls():
 
 
 def get_cli_package_urls():
-    return yaml.load(_get_package_url('cli-premium-packages.yaml'))
+    if is_community():
+        filename = 'cli-packages.yaml'
+    else:
+        filename = 'cli-premium-packages.yaml'
+    return yaml.load(_get_package_url(filename))
 
 
 def get_manager_resources_package_url():
     return _get_package_url('manager-single-tar.yaml').strip(os.linesep)
+
+
+def _get_contents_from_github(repo, path, auth=None):
+    branch = os.environ.get('BRANCH_NAME_CORE', 'master')
+    url = (
+        'https://raw.githubusercontent.com/cloudify-cosmo/'
+        '{repo}/{branch}/{path}'
+    ).format(repo=repo, branch=branch, path=path)
+    r = requests.get(url, auth=auth)
+    if r.status_code != 200:
+        raise RuntimeError(
+            'Error retrieving github content from {url}'.format(url=url)
+        )
+    return r.text
 
 
 def _get_package_url(filename):
@@ -313,19 +331,21 @@ def _get_package_url(filename):
     and GITHUB_PASSWORD exists in env) or locally if the cloudify-premium
     repository is checked out under the same folder the cloudify-system-tests
     repo is checked out."""
-    branch = os.environ.get('BRANCH_NAME_CORE', 'master')
     auth = None
+    if is_community():
+        return _get_contents_from_github(
+            repo='cloudify-versions',
+            path='packages-urls/{filename}'.format(filename=filename),
+        )
+
     if 'GITHUB_USERNAME' in os.environ:
         auth = (os.environ['GITHUB_USERNAME'], os.environ['GITHUB_PASSWORD'])
     if auth:
-        url = 'https://raw.githubusercontent.com/cloudify-cosmo/cloudify-premium/{0}/packages-urls/{1}'.format(branch, filename)  # noqa
-        r = requests.get(url, auth=auth)
-        if r.status_code != 200:
-            raise RuntimeError(
-                'Error getting {0} URL from {1} '
-                '[status_code={2}]: {3}'.format(
-                    filename, url, r.status_code, r.text))
-        return r.text
+        return _get_contents_from_github(
+            repo='cloudify-premium',
+            path='packages-urls/{filename}'.format(filename=filename),
+            auth=auth,
+        )
     else:
         package_url_file = Path(
             os.path.abspath(os.path.join(
@@ -441,3 +461,7 @@ def assert_snapshot_created(manager, snapshot_id, attributes):
     assert r.status_code == 200
     snapshot = AttributesDict(r.json())
     assert snapshot.status == 'created', 'Snapshot not in created status'
+
+
+def is_community():
+    return get_attributes()['image_is_community']

--- a/cosmo_tester/resources/attributes.yaml
+++ b/cosmo_tester/resources/attributes.yaml
@@ -4,6 +4,12 @@ cloudify_username: admin
 cloudify_password: admin
 cloudify_tenant: default_tenant
 
+# This should be set to true if testing community images.
+# This isn't detected by the framework, as doing so would require either some
+# heuristics or deploying managers for each test before determining whether it
+# could be skipped, both of which have a good chance of wasting a lot of time.
+image_is_community: false
+
 # If the latest image name is not set, the latest image name will be generated
 # based on the image name prefix and the currently installed CLI version
 # e.g. cloudify-manager-premium-4.2.dev1

--- a/cosmo_tester/test_suites/bootstrap_based_tests/cli_test.py
+++ b/cosmo_tester/test_suites/bootstrap_based_tests/cli_test.py
@@ -125,7 +125,11 @@ def test_cli_on_rhel_6_9(cli_package_tester, attributes):
 
 def _get_cli_package_url(name):
     urls = util.get_cli_package_urls()
-    return urls['cli_premium_packages_urls'][name]
+    if util.is_community():
+        key = 'cli_packages_urls'
+    else:
+        key = 'cli_premium_packages_urls'
+    return urls[key][name]
 
 
 class _CliPackageTester(object):

--- a/cosmo_tester/test_suites/ha/__init__.py
+++ b/cosmo_tester/test_suites/ha/__init__.py
@@ -1,0 +1,5 @@
+import pytest
+from cosmo_tester.framework.util import is_community
+
+skip_community = pytest.mark.skipif(is_community(),
+                                    reason='Community does not support HA')

--- a/cosmo_tester/test_suites/ha/ha_cluster_scenarios_test.py
+++ b/cosmo_tester/test_suites/ha/ha_cluster_scenarios_test.py
@@ -19,6 +19,12 @@ import time
 from cosmo_tester.framework.examples.hello_world import HelloWorldExample
 from cosmo_tester.framework.cluster import CloudifyCluster
 from .ha_helper import HighAvailabilityHelper as ha_helper
+from . import skip_community
+
+
+# Skip all tests in this module if we're running community tests,
+# using the pytestmark magic variable name
+pytestmark = skip_community
 
 
 @pytest.fixture(scope='function', params=[2, 3])

--- a/cosmo_tester/test_suites/ha/ha_negative_test.py
+++ b/cosmo_tester/test_suites/ha/ha_negative_test.py
@@ -17,6 +17,12 @@ import pytest
 from cosmo_tester.framework.examples.hello_world import HelloWorldExample
 from cosmo_tester.framework.cluster import CloudifyCluster
 from .ha_helper import HighAvailabilityHelper as ha_helper
+from . import skip_community
+
+
+# Skip all tests in this module if we're running community tests,
+# using the pytestmark magic variable name
+pytestmark = skip_community
 
 
 @pytest.fixture(scope='function')

--- a/cosmo_tester/test_suites/snapshots/__init__.py
+++ b/cosmo_tester/test_suites/snapshots/__init__.py
@@ -24,6 +24,7 @@ from cosmo_tester.framework.cluster import (
 )
 from cosmo_tester.framework.util import (
     assert_snapshot_created,
+    is_community,
 )
 # CFY-6912
 from cloudify_cli.commands.executions import (
@@ -54,6 +55,37 @@ TENANT_DEPLOYMENTS_PATH = (
 DEPLOYMENT_ENVIRONMENT_PATH = (
     TENANT_DEPLOYMENTS_PATH + '/{name}'
 )
+
+# These manager versions only support single tenant snapshot restores in
+# premium
+SINGLE_TENANT_MANAGERS = (
+    '3.4.2',
+    # Technically this supports multiple tenants, but we can't restore
+    # snapshots from it with multiple tenants.
+    '4.0',
+)
+# These manager versions support multiple tenant snapshot restores in premium
+MULTI_TENANT_MANAGERS = (
+    '4.0.1',
+    '4.1',
+    'master'
+)
+
+
+def get_single_tenant_versions_list():
+    if is_community():
+        # Community only works single tenanted
+        return SINGLE_TENANT_MANAGERS + MULTI_TENANT_MANAGERS
+    else:
+        return SINGLE_TENANT_MANAGERS
+
+
+def get_multi_tenant_versions_list():
+    if is_community():
+        # Community only works single tenanted
+        return ()
+    else:
+        return MULTI_TENANT_MANAGERS
 
 
 def upgrade_agents(cfy, manager, logger, tenants=('default_tenant',)):

--- a/cosmo_tester/test_suites/snapshots/multi_tenant_snapshot_test.py
+++ b/cosmo_tester/test_suites/snapshots/multi_tenant_snapshot_test.py
@@ -28,6 +28,7 @@ from . import (
     download_snapshot,
     get_deployments_list,
     get_plugins_list,
+    get_multi_tenant_versions_list,
     get_secrets_list,
     NOINSTALL_DEPLOYMENT_ID,
     remove_and_check_deployments,
@@ -123,7 +124,7 @@ def test_restore_snapshot_and_agents_upgrade_multitenant(
 
 @pytest.fixture(
         scope='module',
-        params=['master', '4.1', '4.0.1'])
+        params=get_multi_tenant_versions_list())
 def cluster_multitenant(request, cfy, ssh_key, module_tmpdir, attributes,
                         logger, install_dev_tools=True):
     mt_cluster = cluster(request, cfy, ssh_key, module_tmpdir, attributes,

--- a/cosmo_tester/test_suites/snapshots/single_tenant_snapshot_test.py
+++ b/cosmo_tester/test_suites/snapshots/single_tenant_snapshot_test.py
@@ -30,6 +30,7 @@ from . import (
     get_nodes,
     get_plugins_list,
     get_secrets_list,
+    get_single_tenant_versions_list,
     NOINSTALL_DEPLOYMENT_ID,
     remove_and_check_deployments,
     restore_snapshot,
@@ -67,7 +68,13 @@ def test_restore_snapshot_and_agents_upgrade_singletenant(
 
     assert_hello_worlds([hello_vm], installed=True, logger=logger)
 
-    check_secrets_converted(new_manager, logger)
+    if old_manager.branch_name in ('3.4.2', '4.0'):
+        # Check we convert secrets for pre-service-user versions
+        # In 4.0.1 and beyond we are using service users so the secrets
+        # conversion was determined not to be needed any more as after
+        # that change, keys could no longer be placed in locations that
+        # would not be able to be read by the mgmtworker.
+        check_secrets_converted(new_manager, logger)
     check_plugins(new_manager, old_plugins, logger)
     check_deployments(new_manager, old_deployments, logger)
     check_from_source_plugin(
@@ -87,7 +94,7 @@ def test_restore_snapshot_and_agents_upgrade_singletenant(
 
 @pytest.fixture(
         scope='module',
-        params=['4.0', '3.4.2'])
+        params=get_single_tenant_versions_list())
 def cluster_singletenant(request, cfy, ssh_key, module_tmpdir, attributes,
                          logger, install_dev_tools=True):
     st_cluster = cluster(request, cfy, ssh_key, module_tmpdir, attributes,


### PR DESCRIPTION
I've run all of the tests with the default attributes.yaml (testing on the default latest manager image for all tests on premium) and have had them all work, so there should be no negative impact on currently running tests.

The community tests have the following issues (which I don't think are down to problems with this PR):
1. The snapshot restore tests fail on 4.1 -> current, because of the presence of the cloudify stage files which cause the community manager to try to perform a restore of stage. This is probably best fixed by specifying community versions of the older managers too.
2. Bootstrap tests are currently failing because the bootstrap fails. I believe this is a problem with the current resources single tar.