### PR TITLE
CFY-7190 Download the CA cert instead of the internal cert

### DIFF
--- a/cosmo_tester/resources/attributes.yaml
+++ b/cosmo_tester/resources/attributes.yaml
@@ -58,4 +58,4 @@ medium_flavor_name: m1.medium
 small_flavor_name: m1.small
 manager_server_flavor_name: m1.medium
 
-LOCAL_REST_CERT_FILE: '/etc/cloudify/ssl/cloudify_internal_cert.pem'
+LOCAL_REST_CERT_FILE: '/etc/cloudify/ssl/cloudify_internal_ca_cert.pem'


### PR DESCRIPTION
The CA cert is used for request verification, so this one needs to
be downloaded instead.