### PR TITLE
Fix osx test

### DIFF
--- a/cosmo_tester/resources/terraform/aws-osx-cli-test.tf
+++ b/cosmo_tester/resources/terraform/aws-osx-cli-test.tf
@@ -99,6 +99,7 @@ resource "null_resource" "macincloud" {
       "chmod +x /tmp/osx-cli-test.sh",
       "export MACINCLOUD_PASSWORD=${var.osx_password}",
       "/tmp/osx-cli-test.sh ${var.cli_package_url} /tmp/key.pem ${aws_instance.manager.public_ip} ${aws_instance.manager.private_ip} ${var.manager_user}"
+      "rm -rf /tmp/key.pem"
     ]
   }
 }

--- a/cosmo_tester/resources/terraform/aws-osx-cli-test.tf
+++ b/cosmo_tester/resources/terraform/aws-osx-cli-test.tf
@@ -98,7 +98,7 @@ resource "null_resource" "macincloud" {
     inline = [
       "chmod +x /tmp/osx-cli-test.sh",
       "export MACINCLOUD_PASSWORD=${var.osx_password}",
-      "/tmp/osx-cli-test.sh ${var.cli_package_url} /tmp/key.pem ${aws_instance.manager.public_ip} ${aws_instance.manager.private_ip} ${var.manager_user}"
+      "/tmp/osx-cli-test.sh ${var.cli_package_url} /tmp/key.pem ${aws_instance.manager.public_ip} ${aws_instance.manager.private_ip} ${var.manager_user}",
       "rm -rf /tmp/key.pem"
     ]
   }


### PR DESCRIPTION
missed a comma in terraform file