### PR TITLE
Replace CloudifyCluster.create_*_based with direct calls to subclasses

### DIFF
--- a/cosmo_tester/framework/cluster.py
+++ b/cosmo_tester/framework/cluster.py
@@ -500,59 +500,6 @@ class CloudifyCluster(object):
     def _bootstrap_managers(self):
         pass
 
-    @staticmethod
-    def create_image_based(
-            cfy, ssh_key, tmpdir, attributes, logger,
-            number_of_managers=1,
-            managers=None,
-            create=True,
-            ):
-        """Creates an image based Cloudify manager.
-        :param create: Determines whether to actually create the environment
-         in this invocation. If set to False, create() should be invoked in
-         order to create the environment. Setting it to False allows to
-         change the servers configuration using the servers_config property
-         before calling create().
-        """
-        cluster = ImageBasedCloudifyCluster(
-                cfy,
-                ssh_key,
-                tmpdir,
-                attributes,
-                logger,
-                number_of_managers=number_of_managers,
-                managers=managers,
-                )
-        if create:
-            cluster.create()
-        return cluster
-
-    @staticmethod
-    def create_bootstrap_based(cfy, ssh_key, tmpdir, attributes, logger,
-                               number_of_managers=1,
-                               tf_template=None,
-                               template_inputs=None,
-                               preconfigure_callback=None):
-        """Bootstraps a Cloudify manager using simple manager blueprint."""
-        cluster = BootstrapBasedCloudifyCluster(
-            cfy,
-            ssh_key,
-            tmpdir,
-            attributes,
-            logger,
-            number_of_managers=number_of_managers,
-            tf_template=tf_template,
-            template_inputs=template_inputs
-        )
-        logger.info('Bootstrapping cloudify manager using simple '
-                    'manager blueprint..')
-        if preconfigure_callback:
-            cluster.preconfigure_callback = preconfigure_callback
-        for manager in cluster.managers:
-            manager.image_name = attributes.centos_7_image_name
-        cluster.create()
-        return cluster
-
     def create_openstack_config_file(self):
         openstack_config_file = self._tmpdir / 'openstack_config.json'
         openstack_config_file.write_text(json.dumps({
@@ -678,6 +625,8 @@ class BootstrapBasedCloudifyCluster(CloudifyCluster):
 
     def __init__(self, *args, **kwargs):
         super(BootstrapBasedCloudifyCluster, self).__init__(*args, **kwargs)
+        for manager in self.managers:
+            manager.image_name = self._attributes.centos_7_image_name
         self._manager_resources_package = \
             util.get_manager_resources_package_url()
         self._manager_blueprints_path = None

--- a/cosmo_tester/framework/fixtures.py
+++ b/cosmo_tester/framework/fixtures.py
@@ -1,30 +1,32 @@
 
 import pytest
 
-from .cluster import CloudifyCluster
+from .cluster import BootstrapBasedCloudifyCluster, ImageBasedCloudifyCluster
 
 
 @pytest.fixture(scope='module')
 def image_based_manager(
         request, cfy, ssh_key, module_tmpdir, attributes, logger):
     """Creates a cloudify manager from an image in rackspace OpenStack."""
-    cluster = CloudifyCluster.create_image_based(
-            cfy, ssh_key, module_tmpdir, attributes, logger)
-    cluster.managers[0].use()
-
-    yield cluster.managers[0]
-
-    cluster.destroy()
+    cluster = ImageBasedCloudifyCluster(cfy, ssh_key, module_tmpdir,
+                                        attributes, logger)
+    try:
+        cluster.create()
+        cluster.managers[0].use()
+        yield cluster.managers[0]
+    finally:
+        cluster.destroy()
 
 
 @pytest.fixture(scope='module')
 def bootstrap_based_manager(
         request, cfy, ssh_key, module_tmpdir, attributes, logger):
     """Bootstraps a cloudify manager on a VM in rackspace OpenStack."""
-    cluster = CloudifyCluster.create_bootstrap_based(
-            cfy, ssh_key, module_tmpdir, attributes, logger)
-    cluster.managers[0].use()
-
-    yield cluster.managers[0]
-
-    cluster.destroy()
+    cluster = BootstrapBasedCloudifyCluster(cfy, ssh_key, module_tmpdir,
+                                            attributes, logger)
+    try:
+        cluster.create()
+        cluster.managers[0].use()
+        yield cluster.managers[0]
+    finally:
+        cluster.destroy()

--- a/cosmo_tester/test_suites/bootstrap_based_tests/inplace_upgrade_test.py
+++ b/cosmo_tester/test_suites/bootstrap_based_tests/inplace_upgrade_test.py
@@ -18,7 +18,7 @@ import pytest
 from time import sleep
 from os.path import join
 
-from cosmo_tester.framework.cluster import CloudifyCluster
+from cosmo_tester.framework.cluster import BootstrapBasedCloudifyCluster
 
 from . import get_hello_worlds
 
@@ -27,12 +27,13 @@ from . import get_hello_worlds
 def cluster(request, cfy, ssh_key, module_tmpdir, attributes, logger):
     """Bootstraps a cloudify manager on a VM in rackspace OpenStack."""
     # need to keep the cluster to use its inputs in the second bootstrap
-    cluster = CloudifyCluster.create_bootstrap_based(
-            cfy, ssh_key, module_tmpdir, attributes, logger)
-
-    yield cluster
-
-    cluster.destroy()
+    cluster = BootstrapBasedCloudifyCluster(cfy, ssh_key, module_tmpdir,
+                                            attributes, logger)
+    try:
+        cluster.create()
+        yield cluster
+    finally:
+        cluster.destroy()
 
 
 def test_inplace_upgrade(cfy,

--- a/cosmo_tester/test_suites/bootstrap_based_tests/multi_network_test.py
+++ b/cosmo_tester/test_suites/bootstrap_based_tests/multi_network_test.py
@@ -16,7 +16,7 @@
 import yaml
 import pytest
 
-from cosmo_tester.framework.cluster import CloudifyCluster
+from cosmo_tester.framework.cluster import BootstrapBasedCloudifyCluster
 from cosmo_tester.framework.examples.hello_world import HelloWorldExample
 from cosmo_tester.framework.util import prepare_and_get_test_tenant
 
@@ -34,7 +34,7 @@ from cosmo_tester.test_suites.snapshots import (
 def managers(request, cfy, ssh_key, module_tmpdir, attributes, logger):
     """Bootstraps 2 cloudify managers on a VM in rackspace OpenStack."""
 
-    cluster = CloudifyCluster.create_bootstrap_based(
+    cluster = BootstrapBasedCloudifyCluster(
         cfy, ssh_key, module_tmpdir, attributes, logger,
         number_of_managers=2,
         tf_template='openstack-multi-network-test.tf.template',
@@ -42,13 +42,13 @@ def managers(request, cfy, ssh_key, module_tmpdir, attributes, logger):
             'num_of_networks': request.param,
             'num_of_managers': 2,
             'image_name': attributes.centos_7_image_name
-        },
-        preconfigure_callback=_preconfigure_callback
-    )
-
-    yield cluster.managers
-
-    cluster.destroy()
+        })
+    cluster.preconfigure_callback = _preconfigure_callback
+    try:
+        cluster.create()
+        yield cluster.managers
+    finally:
+        cluster.destroy()
 
 
 def _preconfigure_callback(_managers):

--- a/cosmo_tester/test_suites/ha/ha_cluster_scenarios_test.py
+++ b/cosmo_tester/test_suites/ha/ha_cluster_scenarios_test.py
@@ -17,7 +17,7 @@ import pytest
 import time
 
 from cosmo_tester.framework.examples.hello_world import HelloWorldExample
-from cosmo_tester.framework.cluster import CloudifyCluster
+from cosmo_tester.framework.cluster import ImageBasedCloudifyCluster
 from cosmo_tester.framework.util import prepare_and_get_test_tenant
 from .ha_helper import HighAvailabilityHelper as ha_helper
 from . import skip_community
@@ -33,21 +33,15 @@ def cluster(
         request, cfy, ssh_key, module_tmpdir, attributes, logger):
     """Creates a HA cluster from an image in rackspace OpenStack."""
     logger.info('Creating HA cluster of %s managers', request.param)
-    cluster = CloudifyCluster.create_image_based(
-        cfy,
-        ssh_key,
-        module_tmpdir,
-        attributes,
-        logger,
-        number_of_managers=request.param,
-        create=False)
+    cluster = ImageBasedCloudifyCluster(cfy, ssh_key, module_tmpdir,
+                                        attributes, logger,
+                                        number_of_managers=request.param)
 
     for manager in cluster.managers[1:]:
         manager.upload_plugins = False
 
-    cluster.create()
-
     try:
+        cluster.create()
         manager1 = cluster.managers[0]
         ha_helper.delete_active_profile()
         manager1.use()

--- a/cosmo_tester/test_suites/ha/ha_negative_test.py
+++ b/cosmo_tester/test_suites/ha/ha_negative_test.py
@@ -15,7 +15,7 @@
 
 import pytest
 from cosmo_tester.framework.examples.hello_world import HelloWorldExample
-from cosmo_tester.framework.cluster import CloudifyCluster
+from cosmo_tester.framework.cluster import ImageBasedCloudifyCluster
 from .ha_helper import HighAvailabilityHelper as ha_helper
 from . import skip_community
 
@@ -30,21 +30,15 @@ def cluster(
         request, cfy, ssh_key, module_tmpdir, attributes, logger):
     """Creates a HA cluster from an image in rackspace OpenStack."""
     logger.info('Creating HA cluster of 2 managers')
-    cluster = CloudifyCluster.create_image_based(
-        cfy,
-        ssh_key,
-        module_tmpdir,
-        attributes,
-        logger,
-        number_of_managers=2,
-        create=False)
+    cluster = ImageBasedCloudifyCluster(cfy, ssh_key, module_tmpdir,
+                                        attributes, logger,
+                                        number_of_managers=2)
 
     # manager2 - Cloudify latest - don't install plugins
     cluster.managers[1].upload_plugins = False
 
-    cluster.create()
-
     try:
+        cluster.create()
         manager1 = cluster.managers[0]
         manager2 = cluster.managers[1]
 
@@ -70,21 +64,14 @@ def cluster(
 def test_nonempty_manager_join_cluster_negative(cfy, attributes, ssh_key,
                                                 logger, tmpdir, module_tmpdir):
     logger.info('Creating HA cluster of 2 managers')
-    cluster = CloudifyCluster.create_image_based(
-        cfy,
-        ssh_key,
-        module_tmpdir,
-        attributes,
-        logger,
-        number_of_managers=2,
-        create=False)
-
+    cluster = ImageBasedCloudifyCluster(cfy, ssh_key, module_tmpdir,
+                                        attributes, logger,
+                                        number_of_managers=2)
     # manager2 - Cloudify latest - don't install plugins
     cluster.managers[1].upload_plugins = False
 
-    cluster.create()
-
     try:
+        cluster.create()
         manager1 = cluster.managers[0]
         manager2 = cluster.managers[1]
 

--- a/cosmo_tester/test_suites/snapshots/__init__.py
+++ b/cosmo_tester/test_suites/snapshots/__init__.py
@@ -18,10 +18,7 @@ import json
 import os
 
 import retrying
-from cosmo_tester.framework.cluster import (
-    CloudifyCluster,
-    MANAGERS,
-)
+from cosmo_tester.framework.cluster import ImageBasedCloudifyCluster, MANAGERS
 from cosmo_tester.framework.util import (
     assert_snapshot_created,
     is_community,
@@ -29,7 +26,7 @@ from cosmo_tester.framework.util import (
 # CFY-6912
 from cloudify_cli.commands.executions import (
     _get_deployment_environment_creation_execution,
-    )
+)
 from cloudify_cli.constants import CLOUDIFY_TENANT_HEADER
 
 
@@ -260,8 +257,7 @@ def upload_and_install_helloworld(attributes, logger, manager, target_vm,
     with set_client_tenant(manager, tenant):
         execution = manager.client.executions.start(
             deployment_id,
-            'install',
-            )
+            'install')
     logger.info('Waiting for installation to finish')
     wait_for_execution(
         manager,
@@ -561,15 +557,9 @@ def cluster(request, cfy, ssh_key, module_tmpdir, attributes, logger,
         for mgr_type in manager_types + hello_vms
     ]
 
-    cluster = CloudifyCluster.create_image_based(
-            cfy,
-            ssh_key,
-            module_tmpdir,
-            attributes,
-            logger,
-            managers=managers,
-            )
-
+    cluster = ImageBasedCloudifyCluster(cfy, ssh_key, module_tmpdir,
+                                        attributes, logger, managers=managers)
+    cluster.create()
     if request.param == '4.0.1':
         with managers[0].ssh() as fabric_ssh:
             fabric_ssh.sudo('yum -y -q install wget')


### PR DESCRIPTION
The staticmethods buy us very little, but add a nontrivial amount
of complexity. They do nothing interesting other than just pass
through arguments, but provide no additional abstraction.

Instead of having a `create` argument for the image_based (and one
is going to also be needed for bootstrap_based), we can simply
stop using the staticmethods, but instead always use the right
class directly.

The only non-obvious thing in create_bootstrap_based was setting
the image name, which of course should live in the class itself,
because without it, the class won't work. (it doesn't make sense
to have a class that can only possibly work when created through
the specific factory)