### PR TITLE
BootstrapBasedCluster: pass manager to _bootstrap_manager

### DIFF
--- a/cosmo_tester/framework/cluster.py
+++ b/cosmo_tester/framework/cluster.py
@@ -642,8 +642,7 @@ class BootstrapBasedCloudifyCluster(CloudifyCluster):
 
         self._clone_manager_blueprints()
         for manager in self.managers:
-            inputs_file = self._create_inputs_file(manager)
-            self._bootstrap_manager(inputs_file)
+            self._bootstrap_manager(manager)
 
     def _clone_manager_blueprints(self):
         self._manager_blueprints_path = git_helper.clone(
@@ -671,7 +670,8 @@ class BootstrapBasedCloudifyCluster(CloudifyCluster):
         inputs_file.write_text(bootstrap_inputs_str)
         return inputs_file
 
-    def _bootstrap_manager(self, inputs_file):
+    def _bootstrap_manager(self, manager):
+        inputs_file = self._create_inputs_file(manager)
         manager_blueprint_path = \
             self._manager_blueprints_path / 'simple-manager-blueprint.yaml'
         self._cfy.bootstrap([manager_blueprint_path, '-i', inputs_file])

--- a/cosmo_tester/test_suites/bootstrap_based_tests/inplace_upgrade_test.py
+++ b/cosmo_tester/test_suites/bootstrap_based_tests/inplace_upgrade_test.py
@@ -65,7 +65,7 @@ def test_inplace_upgrade(cfy,
                    interval=1)
     cfy.snapshots.download([snapshot_name, '-o', snapshot_path])
     cfy.teardown(['-f', '--ignore-deployments'])
-    cluster._bootstrap_manager()
+    cluster._bootstrap_manager(manager)
     openstack_config_file = cluster.create_openstack_config_file()
     manager._upload_necessary_files(openstack_config_file)
     cfy.snapshots.upload([snapshot_path, '-s', snapshot_name])


### PR DESCRIPTION
The function used to accept inputs, but it can just as well
accept a manager object and create the inputs.

This way it's easier for the caller, who now needs to only pass
the manager object, instead of creating the inputs file
(using the manager object) and passing that.