### PR TITLE
git_helper: only clone if we didn't already clone before

### DIFF
--- a/cosmo_tester/framework/git_helper.py
+++ b/cosmo_tester/framework/git_helper.py
@@ -36,11 +36,12 @@ def clone(url, basedir, branch=None):
 
     target = path(os.path.join(basedir, 'git', repo_name, branch))
 
-    logger.info("Cloning {0} to {1}".format(url, target))
-    git.clone(url, str(target)).wait()
-    with target:
-        logger.info("Checking out to {0} branch".format(branch))
-        git.checkout(branch).wait()
+    if not target.exists():
+        logger.info("Cloning {0} to {1}".format(url, target))
+        git.clone(url, str(target)).wait()
+        with target:
+            logger.info("Checking out to {0} branch".format(branch))
+            git.checkout(branch).wait()
     return target.abspath()
 
 

--- a/cosmo_tester/framework/git_helper.py
+++ b/cosmo_tester/framework/git_helper.py
@@ -34,7 +34,7 @@ def clone(url, basedir, branch=None):
 
     repo_name = url.split('.git')[0].split('/')[-1]
 
-    target = path(os.path.join(basedir, 'git', repo_name))
+    target = path(os.path.join(basedir, 'git', repo_name, branch))
 
     logger.info("Cloning {0} to {1}".format(url, target))
     git.clone(url, str(target)).wait()


### PR DESCRIPTION
If the repo is already cloned, use what we have, don't attempt to clone again