### PR TITLE
HA tests: before set-active, wait for cluster to stabilize

### DIFF
--- a/cosmo_tester/test_suites/ha/ha_cluster_scenarios_test.py
+++ b/cosmo_tester/test_suites/ha/ha_cluster_scenarios_test.py
@@ -123,6 +123,7 @@ def test_set_active(cfy, hosts, logger):
     manager1 = hosts.instances[0]
     ha_helper.delete_active_profile()
     manager1.use()
+    ha_helper.wait_nodes_online(hosts.instances, logger)
     ha_helper.verify_nodes_status(manager1, cfy, logger)
 
     for manager in hosts.instances[1:]:


### PR DESCRIPTION
Otherwise, we might get an error that we tried to set-active to a node
that is offline (the node will then become online shortly after).