### PR TITLE
Update Centos image to one that include OpenSSL 1.0.2

### DIFF
--- a/cosmo_tester/resources/attributes.yaml
+++ b/cosmo_tester/resources/attributes.yaml
@@ -30,7 +30,7 @@ cli_urls_override:
   osx_cli_package_url: null
 
 centos_7_username: centos
-centos_7_image_name: CentOS-7-x86_64-GenericCloud-1608
+centos_7_image_name: CentOS 7.4 (official)  
 centos_7_AMI: ami-7abd0209
 
 centos_6_username: centos


### PR DESCRIPTION
This OpenSSL version is necessary to install the new `nginx` version we're using now (`nginx-1.13.7-1.el7_4.ngx.x86_64`).

The error otherwise is:
```
Error: Package: 1:nginx-1.13.7-1.el7_4.ngx.x86_64 (/nginx-1.13.7-1.el7_4.ngx.x86_64)
Requires: libcrypto.so.10(OPENSSL_1.0.2)(64bit)
```