### PR TITLE
CFY-7684 Make sure the configuration yaml doesn't contain extra tags

### DIFF
--- a/cosmo_tester/framework/test_hosts.py
+++ b/cosmo_tester/framework/test_hosts.py
@@ -345,8 +345,8 @@ class _CloudifyManager(VM):
         install_config = {
             'manager':
                 {
-                    'public_ip': self.ip_address,
-                    'private_ip': self.private_ip_address,
+                    'public_ip': str(self.ip_address),
+                    'private_ip': str(self.private_ip_address),
                     'security': {
                         'admin_username': self._attributes.cloudify_username,
                         'admin_password': self._attributes.cloudify_password,


### PR DESCRIPTION
ruamel's loader doesn't handle `!!python/unicode` tags well, so we make
sure to keep the configuration strictly ASCII for test purposes