### PR TITLE
HA tests: before starting the test, wait to stabilize

### DIFF
--- a/cosmo_tester/test_suites/ha/ha_cluster_scenarios_test.py
+++ b/cosmo_tester/test_suites/ha/ha_cluster_scenarios_test.py
@@ -58,7 +58,7 @@ def hosts(
                              cluster_node_name=manager.ip_address)
 
         cfy.cluster.nodes.list()
-
+        ha_helper.wait_nodes_online(hosts.instances)
         yield hosts
 
     finally:

--- a/cosmo_tester/test_suites/ha/ha_negative_test.py
+++ b/cosmo_tester/test_suites/ha/ha_negative_test.py
@@ -54,7 +54,7 @@ def hosts(
                          cluster_host_ip=manager2.private_ip_address,
                          cluster_node_name=manager2.ip_address)
         cfy.cluster.nodes.list()
-
+        ha_helper.wait_nodes_online(hosts.instances)
         yield hosts
 
     finally:


### PR DESCRIPTION
joining the cluster doesn't wait for the node to be passing all
health checks, so it was still possible to start a test method
while a replica node didn't fully finish joining, and was still
waiting for its manager-services healthcheck to go green

this change makes it so that we wait for the cluster to fully
stabilize before starting any test method