### PR TITLE
multinetwork test: wait before upgrading agents

### DIFF
--- a/cosmo_tester/test_suites/bootstrap_based_tests/multi_network_test.py
+++ b/cosmo_tester/test_suites/bootstrap_based_tests/multi_network_test.py
@@ -13,6 +13,7 @@
 #    * See the License for the specific language governing permissions and
 #    * limitations under the License.
 
+import time
 import yaml
 import json
 import pytest
@@ -119,6 +120,10 @@ def test_multiple_networks(managers,
 
     upload_snapshot(new_manager, local_snapshot_path, snapshot_id, logger)
     restore_snapshot(new_manager, snapshot_id, cfy, logger)
+
+    # wait a while to allow the restore-snapshot post-workflow commands to run
+    time.sleep(30)
+
     upgrade_agents(cfy, new_manager, logger)
     delete_manager(old_manager, logger)
 


### PR DESCRIPTION
...to allow the post-workflow methods of restore snapshot to run