### PR TITLE
CFY-7877 Access InfluxDB directly via SSH using curl

### DIFF
--- a/cosmo_tester/framework/test_hosts.py
+++ b/cosmo_tester/framework/test_hosts.py
@@ -28,7 +28,6 @@ import retrying
 import sh
 from fabric import api as fabric_api
 from fabric import context_managers as fabric_context_managers
-from influxdb import InfluxDBClient
 
 from cosmo_tester.framework import util
 
@@ -173,8 +172,7 @@ class _CloudifyManager(VM):
         self._tmpdir = os.path.join(tmpdir, str(uuid.uuid4()))
         os.makedirs(self._tmpdir)
         self._openstack = util.create_openstack_client()
-        self.influxdb_client = InfluxDBClient(public_ip_address, 8086,
-                                              'root', 'root', 'cloudify')
+        self.influxdb_url = 'http://localhost:8086/db/cloudify/series?u=root&p=root'  # NOQA
         self.additional_install_config = {}
 
     def upload_necessary_files(self):

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,6 @@ setup(
         'nose',
         'retrying==1.3.3',
         'Jinja2==2.7.2',
-        'influxdb==0.1.13',
         'pywinrm==0.0.3',
         'fasteners==0.13.0',
         # Wagon version has been left out since it better reflects the user


### PR DESCRIPTION
This is because now InfluxDB only binds on `localhost` (whereas it used
to bind on `0.0.0.0`), and we aren't able to access it via the manager's
public IP