### PR TITLE
CY-276 Default no metrics tests, except on heal

### DIFF
--- a/cosmo_tester/framework/test_hosts.py
+++ b/cosmo_tester/framework/test_hosts.py
@@ -172,7 +172,6 @@ class _CloudifyManager(VM):
         self._tmpdir = os.path.join(tmpdir, str(uuid.uuid4()))
         os.makedirs(self._tmpdir)
         self._openstack = util.create_openstack_client()
-        self.influxdb_url = 'http://localhost:8086/db/cloudify/series?u=root&p=root'  # NOQA
         self.additional_install_config = {}
 
     def upload_necessary_files(self):

--- a/cosmo_tester/resources/blueprints/openstack-start-vm/blueprint.yaml
+++ b/cosmo_tester/resources/blueprints/openstack-start-vm/blueprint.yaml
@@ -88,8 +88,6 @@ node_templates:
           remote_ip_prefix: 0.0.0.0/0
         - port: 8080
           remote_ip_prefix: 0.0.0.0/0
-        - port: 8086
-          remote_ip_prefix: 0.0.0.0/0
         - port: 5555
           remote_ip_prefix: { get_property: [subnet, subnet, cidr] }
         - port: 5672

--- a/cosmo_tester/resources/terraform/openstack-multi-network-test.tf.template
+++ b/cosmo_tester/resources/terraform/openstack-multi-network-test.tf.template
@@ -79,12 +79,6 @@ resource "openstack_compute_secgroup_v2" "security_group" {
     cidr = "0.0.0.0/0"
   }
   rule {
-    from_port = 8086
-    to_port = 8086
-    ip_protocol = "tcp"
-    cidr = "0.0.0.0/0"
-  }
-  rule {
     from_port = 8080
     to_port = 8080
     ip_protocol = "tcp"

--- a/cosmo_tester/resources/terraform/openstack-vm.tf.template
+++ b/cosmo_tester/resources/terraform/openstack-vm.tf.template
@@ -58,12 +58,6 @@ resource "openstack_compute_secgroup_v2" "security_group" {
     cidr = "0.0.0.0/0"
   }
   rule {
-    from_port = 8086
-    to_port = 8086
-    ip_protocol = "tcp"
-    cidr = "0.0.0.0/0"
-  }
-  rule {
     from_port = 8080
     to_port = 8080
     ip_protocol = "tcp"

--- a/cosmo_tester/test_suites/image_based_tests/hello_world_test.py
+++ b/cosmo_tester/test_suites/image_based_tests/hello_world_test.py
@@ -51,10 +51,8 @@ def hello_world(request, cfy, manager, attributes, ssh_key, tmpdir, logger):
     if 'windows' in request.param:
         hw.blueprint_file = 'openstack-windows-blueprint.yaml'
         hw.inputs.update({
-            'flavor': attributes['medium_flavor_name'],
+            'flavor': attributes['large_flavor_name'],
         })
-        # The windows hello world blueprint doesn't have monitoring set up
-        hw.verify_metrics = False
     else:
         hw.blueprint_file = 'openstack-blueprint.yaml'
         hw.inputs.update({


### PR DESCRIPTION
Preparation for making the metrics+policy engine not be in the manager by default.