### PR TITLE
Upgrading openstacksdk to latest version 0.13.0 because of the error:…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         'wagon[venv]==0.6.3',
         'pytest==3.0.4',
         'testtools==2.2.0',
-        'openstacksdk==0.9.13'
+        'openstacksdk==0.13.0'
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
…  ImportError: cannot import name _log