### PR TITLE
Wait for plugin_install execution to finish after plugin upload

### DIFF
--- a/cosmo_tester/framework/test_hosts.py
+++ b/cosmo_tester/framework/test_hosts.py
@@ -239,6 +239,8 @@ class _CloudifyManager(VM):
                 # compatible and cfy isn't installed in the image
                 self.client.plugins.upload(plugin['wgn_url'])
 
+        util.wait_for_all_executions(self)
+
     @property
     def remote_private_key_path(self):
         """Returns the private key path on the manager."""


### PR DESCRIPTION
If we don't wait, we might be in a state where the above (system-wide)
exec is still running and we're trying to start another one, which
might fail