### PR TITLE
CY-166 : enable running system tests without creating a branch in the examples repos

### DIFF
--- a/cosmo_tester/framework/examples/__init__.py
+++ b/cosmo_tester/framework/examples/__init__.py
@@ -157,6 +157,17 @@ class AbstractExample(testtools.TestCase):
             destination = os.path.join(
                 str(self.tmpdir), 'examples', self.suffix,
             )
+
+            self.branch = self.branch or os.environ.get(
+                'BRANCH_NAME_CORE',
+                git_helper.MASTER_BRANCH)
+
+            if not git_helper.check_branch_or_tag_exists(self.branch):
+                self.logger.info("{0} branch/tag does not exists in examples "
+                                 "repos, so defaults to there master"
+                                 "branch".format(self.branch))
+                self.branch = git_helper.MASTER_BRANCH
+
             self._cloned_to = git_helper.clone(self.REPOSITORY_URL,
                                                destination,
                                                branch=self.branch)

--- a/cosmo_tester/framework/git_helper.py
+++ b/cosmo_tester/framework/git_helper.py
@@ -22,16 +22,20 @@ from path import path
 
 from cosmo_tester.framework.util import sh_bake
 
+MASTER_BRANCH = 'master'
 
 logger = logging.getLogger('git_helper')
 logger.setLevel(logging.INFO)
 git = sh_bake(sh.git)
 
 
+def check_branch_or_tag_exists(branch):
+    return \
+        git('show-ref', '--verify', '--', "refs/remotes/origin/" + branch) or\
+        git('show-ref', '--verify', '--', 'refs/tags/' + branch)
+
+
 def clone(url, basedir, branch=None):
-
-    branch = branch or os.environ.get('BRANCH_NAME_CORE', 'master')
-
     repo_name = url.split('.git')[0].split('/')[-1]
 
     target = path(os.path.join(basedir, 'git', repo_name, branch))


### PR DESCRIPTION
This is unnecessary move because not all branches need to change the examples repos also