### PR TITLE
CY-166 : fixing check if branch/tag exists

### DIFF
--- a/cosmo_tester/framework/examples/__init__.py
+++ b/cosmo_tester/framework/examples/__init__.py
@@ -162,15 +162,9 @@ class AbstractExample(testtools.TestCase):
                 'BRANCH_NAME_CORE',
                 git_helper.MASTER_BRANCH)
 
-            if not git_helper.check_branch_or_tag_exists(self.branch):
-                self.logger.info("{0} branch/tag does not exists in examples "
-                                 "repos, so defaults to there master"
-                                 "branch".format(self.branch))
-                self.branch = git_helper.MASTER_BRANCH
-
             self._cloned_to = git_helper.clone(self.REPOSITORY_URL,
                                                destination,
-                                               branch=self.branch)
+                                               self.branch)
 
     def cleanup(self, allow_custom_params=False):
         if self._cleanup_required:

--- a/cosmo_tester/framework/git_helper.py
+++ b/cosmo_tester/framework/git_helper.py
@@ -29,12 +29,6 @@ logger.setLevel(logging.INFO)
 git = sh_bake(sh.git)
 
 
-def check_branch_or_tag_exists(branch):
-    return \
-        git('show-ref', '--verify', '--', "refs/remotes/origin/" + branch) or\
-        git('show-ref', '--verify', '--', 'refs/tags/' + branch)
-
-
 def clone(url, basedir, branch=None):
     repo_name = url.split('.git')[0].split('/')[-1]
 
@@ -44,8 +38,14 @@ def clone(url, basedir, branch=None):
         logger.info("Cloning {0} to {1}".format(url, target))
         git.clone(url, str(target)).wait()
         with target:
-            logger.info("Checking out to {0} branch".format(branch))
-            git.checkout(branch).wait()
+            try:
+                logger.info("Trying to check out to {0} branch".format(branch))
+                git.checkout(branch).wait()
+            except Exception:
+                logger.info("{0} branch/tag was not found in {1} "
+                            "repo, so defaults to master"
+                            "branch".format(branch, url))
+                git.checkout(MASTER_BRANCH)
     return target.abspath()
 
 


### PR DESCRIPTION
Because we don't know if we deal with a branch or a tag, so
the simplest way is to relay on git checks.