### PR TITLE
CY-586 Add log saving for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,12 +52,21 @@ source my-openrc.sh
 
 Run:
 ```python
-pytest -s hello_world_test.py::test_hello_world
+pytest -s cosmo_tester/test_suites/image_based_tests/hello_world_test.py::test_hello_world
 ```
 
-Please note it is important to run tests with the `-s` flag as the framework uses `Fabric` which is known to have problems with pytest's output capturing (https://github.com/pytest-dev/pytest/issues/1585).
+**Please note it is important to run tests with the `-s` flag as the framework uses `Fabric` which is known to have problems with pytest's output capturing (https://github.com/pytest-dev/pytest/issues/1585).**
 
+### Saving the Cloudify Manager's logs
+In order to save the logs of tests, specify the path via an environment variable as follows:
 
+`export CFY_LOGS_PATH_LOCAL=<YOUR-PATH-HERE>`
+
+For example you may use:
+```bash
+export CFY_LOGS_PATH_LOCAL=~/cfy_logs/
+```
+which will save the logs to `~/cfy/_logs/` of only the failed tests.
 ## Writing tests
 
 ## Test based on Cloudify manager started using an image

--- a/cosmo_tester/framework/examples/__init__.py
+++ b/cosmo_tester/framework/examples/__init__.py
@@ -188,3 +188,7 @@ class AbstractExample(testtools.TestCase):
         self.assertGreater(len(events), 0,
                            'There are no events for deployment: {0}'.format(
                                    self.deployment_id))
+
+    @property
+    def ssh_key(self):
+        return self._ssh_key

--- a/cosmo_tester/framework/util.py
+++ b/cosmo_tester/framework/util.py
@@ -24,6 +24,8 @@ import subprocess
 import requests
 import retrying
 import yaml
+import errno
+from os import makedirs
 
 from openstack import connection as openstack_connection
 from path import path, Path
@@ -425,3 +427,13 @@ def prepare_and_get_test_tenant(test_param, manager, cfy):
         manager.upload_plugin(default_openstack_plugin,
                               tenant_name=tenant)
     return tenant
+
+
+def mkdirs(folder_path):
+    try:
+        makedirs(folder_path)
+    except OSError as exc:
+        if exc.errno == errno.EEXIST and os.path.isdir(folder_path):
+            pass
+        else:
+            raise


### PR DESCRIPTION
- Setting `CFY_LOGS_PATH_LOCAL` path as an env var will save logs of
test modules.
- Setting `SKIP_LOG_SAVE_ON_SUCCESS=True` will make sure not to save
logs when the tests are successful.