### PR TITLE
Snapshots: change credentials before running verify_services

### DIFF
--- a/cosmo_tester/test_suites/snapshots/__init__.py
+++ b/cosmo_tester/test_suites/snapshots/__init__.py
@@ -465,7 +465,8 @@ def prepare_credentials_tests(cfy, logger, manager):
 
 def update_credentials(cfy, logger, manager):
     logger.info('Changing to modified admin credentials')
-    change_profile_credentials('admin', CHANGED_ADMIN_PASSWORD, cfy)
+    change_profile_credentials('admin', CHANGED_ADMIN_PASSWORD, cfy,
+                               validate=False)
     change_rest_client_password(manager, CHANGED_ADMIN_PASSWORD)
 
 
@@ -496,8 +497,11 @@ def test_user(username, password, cfy, logger, admin_password='admin'):
     cfy.profiles.set(['-u', 'admin', '-p', admin_password])
 
 
-def change_profile_credentials(username, password, cfy):
-    cfy.profiles.set(['-u', username, '-p', password])
+def change_profile_credentials(username, password, cfy, validate=True):
+    cmd = ['-u', username, '-p', password]
+    if not validate:
+        cmd.append('--skip-credentials-validation')
+    cfy.profiles.set(cmd)
 
 
 def update_admin_password(new_password, cfy):

--- a/cosmo_tester/test_suites/snapshots/__init__.py
+++ b/cosmo_tester/test_suites/snapshots/__init__.py
@@ -463,10 +463,13 @@ def prepare_credentials_tests(cfy, logger, manager):
     change_rest_client_password(manager, CHANGED_ADMIN_PASSWORD)
 
 
-def check_credentials(cfy, logger, manager):
+def update_credentials(cfy, logger, manager):
     logger.info('Changing to modified admin credentials')
     change_profile_credentials('admin', CHANGED_ADMIN_PASSWORD, cfy)
     change_rest_client_password(manager, CHANGED_ADMIN_PASSWORD)
+
+
+def check_credentials(cfy, logger, manager):
     logger.info('Checking test user still works')
     test_user('testuser', 'testpass', cfy, logger, CHANGED_ADMIN_PASSWORD)
 

--- a/cosmo_tester/test_suites/snapshots/multi_tenant_snapshot_test.py
+++ b/cosmo_tester/test_suites/snapshots/multi_tenant_snapshot_test.py
@@ -39,6 +39,7 @@ from . import (
     restore_snapshot,
     set_client_tenant,
     SNAPSHOT_ID,
+    update_credentials,
     upgrade_agents,
     upload_and_install_helloworld,
     upload_snapshot,
@@ -105,6 +106,9 @@ def test_restore_snapshot_and_agents_upgrade_multitenant(
     upload_snapshot(new_manager, local_snapshot_path, SNAPSHOT_ID, logger)
 
     restore_snapshot(new_manager, SNAPSHOT_ID, cfy, logger)
+
+    if manager_supports_users_in_snapshot_creation(old_manager):
+        update_credentials(cfy, logger, new_manager)
 
     verify_services_status(new_manager, logger)
 

--- a/cosmo_tester/test_suites/snapshots/single_tenant_snapshot_test.py
+++ b/cosmo_tester/test_suites/snapshots/single_tenant_snapshot_test.py
@@ -39,6 +39,7 @@ from . import (
     remove_and_check_deployments,
     restore_snapshot,
     SNAPSHOT_ID,
+    update_credentials,
     upgrade_agents,
     upload_and_install_helloworld,
     upload_snapshot,
@@ -73,6 +74,9 @@ def test_restore_snapshot_and_agents_upgrade_singletenant(
     upload_snapshot(new_manager, local_snapshot_path, SNAPSHOT_ID, logger)
 
     restore_snapshot(new_manager, SNAPSHOT_ID, cfy, logger)
+
+    if manager_supports_users_in_snapshot_creation(old_manager):
+        update_credentials(cfy, logger, new_manager)
 
     verify_services_status(new_manager, logger)
 


### PR DESCRIPTION
Snapshot restore changes the credentials on manager post-execution.
If this happens to run before the test runs verify_services_status,
then the verify call will never succeed.

Instead, let's update the stored credentials before running those
requests, so that they run with the changed credentials already.