### PR TITLE
CY-586 Add manager branch or image name as test tar file name prefix

### DIFF
--- a/cosmo_tester/framework/fixtures.py
+++ b/cosmo_tester/framework/fixtures.py
@@ -9,7 +9,7 @@ def image_based_manager(
         request, cfy, ssh_key, module_tmpdir, attributes, logger):
     """Creates a cloudify manager from an image in rackspace OpenStack."""
     hosts = TestHosts(
-            cfy, ssh_key, module_tmpdir, attributes, logger)
+            cfy, ssh_key, module_tmpdir, attributes, logger, request=request)
     try:
         hosts.create()
         hosts.instances[0].use()

--- a/cosmo_tester/test_suites/ha/ha_cluster_scenarios_test.py
+++ b/cosmo_tester/test_suites/ha/ha_cluster_scenarios_test.py
@@ -36,7 +36,7 @@ def hosts(
     logger.info('Creating HA cluster of %s managers', request.param)
     hosts = TestHosts(
         cfy, ssh_key, module_tmpdir, attributes, logger,
-        number_of_instances=request.param)
+        number_of_instances=request.param, request=request)
 
     for manager in hosts.instances[1:]:
         manager.upload_plugins = False

--- a/cosmo_tester/test_suites/ha/ha_negative_test.py
+++ b/cosmo_tester/test_suites/ha/ha_negative_test.py
@@ -32,7 +32,7 @@ def hosts(
     logger.info('Creating HA cluster of 2 managers')
     hosts = TestHosts(
         cfy, ssh_key, module_tmpdir, attributes, logger,
-        number_of_instances=2)
+        number_of_instances=2, request=request)
 
     # manager2 - Cloudify latest - don't install plugins
     hosts.instances[1].upload_plugins = False

--- a/cosmo_tester/test_suites/snapshots/__init__.py
+++ b/cosmo_tester/test_suites/snapshots/__init__.py
@@ -745,7 +745,7 @@ def hosts(
 
     hosts = TestHosts(
         cfy, ssh_key, module_tmpdir,
-        attributes, logger, instances=instances)
+        attributes, logger, instances=instances, request=request)
     hosts.create()
 
     if request.param == '4.0.1':


### PR DESCRIPTION
Replaces old `log.tar.gz` file name format to `<Class Instance Name>__<Pytest Test Parameter (if reachable)>__<Instance Index in the TestHosts Instances List>__<Terraform Instance ID>`