### PR TITLE
Move cryptography_utils to cloudify-common

### DIFF
--- a/cosmo_tester/test_suites/image_based_tests/cfy_manager_test.py
+++ b/cosmo_tester/test_suites/image_based_tests/cfy_manager_test.py
@@ -39,7 +39,8 @@ MQ_PASSWORDS_PATH = '/tmp/passwords'
 GET_MQ_PASSWORDS_CODE = '''
 import json
 
-from manager_rest.cryptography_utils import decrypt
+from cloudify.cryptography_utils import decrypt
+
 from manager_rest.storage import models
 from manager_rest.flask_utils import setup_flask_app
 


### PR DESCRIPTION
This way it can be used easily during snapshot restore