### PR TITLE
TestHosts: use `systemctl -a`

### DIFF
--- a/cosmo_tester/framework/test_hosts.py
+++ b/cosmo_tester/framework/test_hosts.py
@@ -396,7 +396,7 @@ class _CloudifyManager(VM):
             # is done.
             try:
                 # will fail on bootstrap based managers
-                fabric_ssh.run('systemctl | grep manager-ip-setter')
+                fabric_ssh.run('systemctl -a | grep manager-ip-setter')
             except Exception:
                 pass
             else:


### PR DESCRIPTION
Grepping like that only shows active units, but if ipsetter already finished,
it won't be in `systemctl`, but it will be in `systemctl -a`