### PR TITLE
CY-2450 Remove 'upload_necessary_files'

### DIFF
--- a/cosmo_tester/test_suites/agent/__init__.py
+++ b/cosmo_tester/test_suites/agent/__init__.py
@@ -8,10 +8,8 @@ def get_test_prerequisites(cfy, ssh_key, module_tmpdir, test_config, logger,
     hosts.instances[1] = get_image('centos', test_config)
     manager, vm = hosts.instances
 
-    manager.upload_files = False
     manager.restservice_expected = True
 
-    vm.upload_files = False
     image_name = test_config.platform['{}_image'.format(vm_os)]
     username = test_config['test_os_usernames'][vm_os]
 

--- a/cosmo_tester/test_suites/agent/test_upgrade.py
+++ b/cosmo_tester/test_suites/agent/test_upgrade.py
@@ -19,12 +19,9 @@ def managers_and_vm(cfy, ssh_key, module_tmpdir, test_config, logger,
         managers = hosts.instances[:2]
         vm = hosts.instances[2]
 
-        managers[0].upload_files = False
-        managers[1].upload_files = False
         managers[0].restservice_expected = True
         managers[1].restservice_expected = True
 
-        vm.upload_files = False
         vm.image_name = test_config.platform['centos_7_image']
         vm.username = test_config['test_os_usernames']['centos_7']
 

--- a/cosmo_tester/test_suites/bootstrap_based_tests/multi_network_test.py
+++ b/cosmo_tester/test_suites/bootstrap_based_tests/multi_network_test.py
@@ -33,7 +33,6 @@ def managers_and_vms(cfy, ssh_key, module_tmpdir, test_config, logger,
     )
 
     for inst in [2, 3, 4]:
-        hosts.instances[inst].upload_files = False
         hosts.instances[inst].image_name = test_config.platform[
             'centos_7_image']
         hosts.instances[inst].username = test_config[
@@ -183,9 +182,7 @@ def proxy_hosts(request, cfy, ssh_key, module_tmpdir, test_config, logger):
         bootstrappable=True,)
     proxy, manager, vm = hosts.instances
 
-    proxy.upload_files = False
     proxy.image_name = test_config.platform['centos_7_image']
-    vm.upload_files = False
     vm.image_name = test_config.platform['centos_7_image']
 
     passed = True

--- a/cosmo_tester/test_suites/cluster/broker_management_test.py
+++ b/cosmo_tester/test_suites/cluster/broker_management_test.py
@@ -359,8 +359,6 @@ def test_broker_management(brokers_and_manager, logger):
     # operations increases to the point that extra tests are needed.
     broker1, broker2, manager = brokers_and_manager
 
-    manager.enter_sanity_mode()
-
     expected_1 = {
         'port': 5671,
         'networks': {'default': str(broker1.private_ip_address)},

--- a/cosmo_tester/test_suites/cluster/conftest.py
+++ b/cosmo_tester/test_suites/cluster/conftest.py
@@ -127,7 +127,6 @@ def _get_hosts(cfy, ssh_key, module_tmpdir, test_config, logger, request,
     try:
         for node in hosts.instances:
             node.verify_services_are_running = skip
-            node.upload_necessary_files = skip
 
         hosts.create()
 
@@ -284,11 +283,9 @@ def _bootstrap_rabbit_node(node, rabbit_num, brokers, skip_bootstrap_list,
         return
 
     if pre_cluster_rabbit and rabbit_num == 1:
-        node.bootstrap(blocking=True, enter_sanity_mode=False,
-                       restservice_expected=False)
+        node.bootstrap(blocking=True, restservice_expected=False)
     else:
-        node.bootstrap(blocking=False, enter_sanity_mode=False,
-                       restservice_expected=False)
+        node.bootstrap(blocking=False, restservice_expected=False)
 
 
 def _bootstrap_db_node(node, db_num, dbs, skip_bootstrap_list, high_security,
@@ -338,8 +335,7 @@ def _bootstrap_db_node(node, db_num, dbs, skip_bootstrap_list, high_security,
     if node.friendly_name in skip_bootstrap_list:
         return
 
-    node.bootstrap(blocking=False, enter_sanity_mode=False,
-                   restservice_expected=False)
+    node.bootstrap(blocking=False, restservice_expected=False)
 
 
 def _bootstrap_manager_node(node, mgr_num, dbs, brokers, skip_bootstrap_list,

--- a/cosmo_tester/test_suites/cluster/db_management_test.py
+++ b/cosmo_tester/test_suites/cluster/db_management_test.py
@@ -53,8 +53,7 @@ def test_add_db_node(cluster_missing_one_db, logger, cfy):
     _check_db_count(mgr1, mgr2, db3, all_present=False)
 
     logger.info('Adding extra DB')
-    db3.bootstrap(blocking=True, enter_sanity_mode=False,
-                  restservice_expected=False)
+    db3.bootstrap(blocking=True, restservice_expected=False)
     db3_node_id = db3.get_node_id()
     mgr1.run_command('cfy_manager dbs add -a {0} -i {1}'.format(
         db3.private_ip_address, db3_node_id

--- a/cosmo_tester/test_suites/image_based_tests/inplace_upgrade_test.py
+++ b/cosmo_tester/test_suites/image_based_tests/inplace_upgrade_test.py
@@ -18,10 +18,8 @@ def manager_and_vm(request, cfy, ssh_key, module_tmpdir, test_config,
     hosts.instances[0] = get_image(request.param, test_config)
     manager, vm = hosts.instances
 
-    manager.upload_files = False
     manager.restservice_expected = True
 
-    vm.upload_files = False
     vm.image_name = test_config.platform['centos_7_image']
     vm.username = test_config['test_os_usernames']['centos_7']
 
@@ -75,7 +73,6 @@ def test_inplace_upgrade(cfy,
         fabric_ssh.sudo('rm -rf /var/lib/rabbitmq')
     manager.bootstrap()
     manager.use()
-    manager.upload_necessary_files()
     cfy.snapshots.upload([snapshot_path, '-s', snapshot_name])
 
     with manager.ssh() as fabric_ssh:

--- a/cosmo_tester/test_suites/manager_of_managers/constants.py
+++ b/cosmo_tester/test_suites/manager_of_managers/constants.py
@@ -13,12 +13,6 @@
 #    * See the License for the specific language governing permissions and
 #    * limitations under the License.
 
-from cosmo_tester.framework.test_hosts import (
-    REMOTE_OPENSTACK_CONFIG_PATH,
-    REMOTE_PRIVATE_KEY_PATH,
-    REMOTE_PUBLIC_KEY_PATH
-)
-
 MOM_PLUGIN_REPO_PATH = 'cloudify-cosmo/cloudify-spire-plugin'
 MOM_PLUGIN_VERSION = '3.2.4'
 MOM_PLUGIN_RELEASE_NAME = '{0}'.format(MOM_PLUGIN_VERSION)
@@ -99,29 +93,6 @@ SCRIPT_PY_PATH = '/etc/cloudify/script_2.py'
 SSH_KEY_TMP_PATH = '/etc/cloudify/private.key'
 PUB_KEY_TMP_PATH = '/etc/cloudify/public.key'
 OS_CONFIG_TMP_PATH = '/tmp/openstack_config.json'
-
-SH_SCRIPT = '''#!/usr/bin/env bash
-echo "Moving the SSH key..."
-sudo cp {tmp_ssh_key_path} {ssh_key_path}
-sudo chown cfyuser: {ssh_key_path}
-sudo cp {tmp_ssh_public_key_path} {ssh_key_path}
-sudo chown cfyuser: {tmp_ssh_public_key_path}
-
-echo "Moving the OS config..."
-sudo cp {tmp_os_config_path} {os_config_path}
-sudo chown cfyuser: {os_config_path}
-
-echo "Entering sanity mode..."
-sudo touch /opt/manager/sanity_mode
-sudo chown cfyuser:cfyuser /opt/manager/sanity_mode
-sudo chmod 440 /opt/manager/sanity_mode
-'''.format(
-    tmp_ssh_key_path=SSH_KEY_TMP_PATH,
-    ssh_key_path=REMOTE_PRIVATE_KEY_PATH,
-    tmp_ssh_public_key_path=REMOTE_PUBLIC_KEY_PATH,
-    tmp_os_config_path=OS_CONFIG_TMP_PATH,
-    os_config_path=REMOTE_OPENSTACK_CONFIG_PATH
-)
 
 PY_SCRIPT = '''#!/usr/bin/env python
 print 'Running a python script!'

--- a/cosmo_tester/test_suites/snapshots/conftest.py
+++ b/cosmo_tester/test_suites/snapshots/conftest.py
@@ -15,7 +15,6 @@ def hosts(request, cfy, ssh_key, module_tmpdir, test_config, logger):
     hosts.instances[0].image_type = request.param
 
     vm = hosts.instances[2]
-    vm.upload_files = False
     vm.image_name = test_config.platform['centos_7_image']
     vm.username = test_config['test_os_usernames']['centos_7']
 


### PR DESCRIPTION
They're not necessary, so let's not upload them.
This also scraps sanity mode for manager tests.