### PR TITLE
Replace v2.0 with v3 in openstack auth URLs

### DIFF
--- a/cosmo_tester/conf_cli.py
+++ b/cosmo_tester/conf_cli.py
@@ -95,7 +95,7 @@ def apply_platform_config(logger, config, platform):
             os.environ.get("OS_TENANT_NAME")
             or os.environ['OS_PROJECT_NAME']
         )
-        target['url'] = os.environ["OS_AUTH_URL"]
+        target['url'] = os.environ["OS_AUTH_URL"].replace('v2.0', 'v3')
         target['region'] = os.environ.get("OS_REGION_NAME", "RegionOne")
 
 

--- a/cosmo_tester/test_suites/cluster/db_management_test.py
+++ b/cosmo_tester/test_suites/cluster/db_management_test.py
@@ -139,8 +139,8 @@ def test_fail_to_remove_db_leader(dbs, logger):
             _get_leader(listing),
         )
     )
-    assert 'Failed' in result
-    assert 'cannot be removed' in result
+    assert 'Failed' in result.stdout
+    assert 'cannot be removed' in result.stdout
 
 
 def test_fail_to_reinit(dbs, logger):
@@ -153,8 +153,8 @@ def test_fail_to_reinit(dbs, logger):
             _get_leader(listing),
         )
     )
-    assert 'Failed' in result
-    assert 'cannot be reinitialised' in result
+    assert 'Failed' in result.stdout
+    assert 'cannot be reinitialised' in result.stdout
 
 
 def _check_cluster(listing, expected_leader=None):
@@ -221,7 +221,7 @@ def _get_db_listing(nodes):
     for node in nodes:
         result = [
             line for line in
-            node.run_command('cfy_manager dbs list').splitlines()[4:-1]
+            node.run_command('cfy_manager dbs list').stdout.splitlines()[4:-1]
         ]
         results.append(_structure_db_listing(result))
 


### PR DESCRIPTION
Some of the openstackrcs we have have v2.0 in the URL, which causes unhelpful errors.
This will replace them automatically with v3 if the config generation CLI tool is used.