### PR TITLE
Don't require package urls to be set

### DIFF
--- a/cosmo_tester/config_schemas/package_urls.yaml
+++ b/cosmo_tester/config_schemas/package_urls.yaml
@@ -3,7 +3,9 @@ community:
   description: Path relative to root of repo to local copy of repository containing package URLs for community. This should probably be the cloudify-version repo.
   default: ../cloudify-versions
   validate_existing_dir: true
+  nullable: true
 premium:
   description: Path relative to root of repo to local copy of repository containing package URLs for premium. This should probably be the cloudify-premium repo, or 'null' if testing community.
   default: ../cloudify-premium
   validate_optional_dir: true
+  nullable: true


### PR DESCRIPTION
Community tests will fail with premium nulled otherwise.