### PR TITLE
CY-3259 Check correct dep count in component test

### DIFF
--- a/cosmo_tester/test_suites/service_composition/component_test.py
+++ b/cosmo_tester/test_suites/service_composition/component_test.py
@@ -24,7 +24,7 @@ def test_component(image_based_manager, ssh_key, logger, test_config):
         # verify that uninstall of app removes the infra + its deployment
         logger.info('Testing component uninstall.')
         app.uninstall()
-        assert len(app.manager.client.deployments.list()) == 1
+        assert len(app.manager.client.deployments.list()) == 0
 
 
 def test_nested_components(image_based_manager, ssh_key, logger, test_config):


### PR DESCRIPTION
Because of the automatic deletion of deployment since the new examples were introduced,
the expected deployment count was incorrect.