### PR TITLE
Changing key-path to list

### DIFF
--- a/cosmo_tester/framework/test_hosts.py
+++ b/cosmo_tester/framework/test_hosts.py
@@ -167,7 +167,7 @@ $user.SetInfo()""".format(fw_cmd=add_firewall_cmd,
             host=self.ip_address,
             user=self.username,
             connect_kwargs={
-                'key_filename': self.private_key_path,
+                'key_filename': [self.private_key_path],
             },
             port=22,
             connect_timeout=3,


### PR DESCRIPTION
Although Fabric specifies in the documentation that the `key_filename` value should be a string, it sometimes throws an error when it's not given as part of a list. We haven't figured out yet what "sometimes" means, but for now, we'll put the key file path in a list.