### PR TITLE
CY-3586 Adding three-nodes-cluster fixture

### DIFF
--- a/cosmo_tester/test_suites/cluster/conftest.py
+++ b/cosmo_tester/test_suites/cluster/conftest.py
@@ -130,17 +130,14 @@ def _get_hosts(ssh_key, module_tmpdir, test_config, logger, request,
                # and use postgres client certs.
                pre_cluster_rabbit=False, high_security=True,
                use_hostnames=False, three_nodes_cluster=False):
-    if three_nodes_cluster:
-        # If small_cluster == True, the services' counts will be ignored
-        broker_count = manager_count = db_count = 1
+    number_of_instances = (3 if three_nodes_cluster
+                           else broker_count + db_count + manager_count)
+    number_of_instances = number_of_instances + (1 if use_load_balancer else 0)
     if skip_bootstrap_list is None:
         skip_bootstrap_list = []
     hosts = Hosts(
         ssh_key, module_tmpdir, test_config, logger, request,
-        number_of_instances=broker_count + db_count + manager_count + (
-            1 if use_load_balancer else 0
-        ),
-        bootstrappable=True)
+        number_of_instances=number_of_instances, bootstrappable=True)
 
     tempdir = hosts._tmpdir
 
@@ -182,7 +179,7 @@ def _get_hosts(ssh_key, module_tmpdir, test_config, logger, request,
             managers = hosts.instances[broker_count + db_count:
                                        broker_count + db_count + manager_count]
         if use_load_balancer:
-            lb = hosts.instances[broker_count + db_count + manager_count]
+            lb = hosts.instances[number_of_instances]
 
         for node_num, node in enumerate(brokers, start=1):
             _bootstrap_rabbit_node(node, node_num, brokers,

--- a/cosmo_tester/test_suites/cluster/full_cluster_test.py
+++ b/cosmo_tester/test_suites/cluster/full_cluster_test.py
@@ -359,7 +359,7 @@ def _verify_agent_broker_connection_and_get_broker_ip(agent_node):
     assert connection_established   # error if no connection on rabbit port
 
 
-def test_cluster_status(full_cluster_ips, logger, module_tmpdir):
+def test_full_cluster_status(full_cluster_ips, logger, module_tmpdir):
     broker1, broker2, broker3, db1, db2, db3, mgr1, mgr2 = full_cluster_ips
 
     _assert_cluster_status(mgr1.client)
@@ -367,6 +367,15 @@ def test_cluster_status(full_cluster_ips, logger, module_tmpdir):
     _verify_status_when_postgres_inactive(db1, db2, logger, mgr1.client)
     _verify_status_when_rabbit_inactive(broker1, broker2, broker3, logger,
                                         mgr1.client)
+
+
+def test_three_nodes_cluster_status(three_nodes_cluster, logger):
+    node1, node2, node3 = three_nodes_cluster
+    _assert_cluster_status(node1.client)
+    _verify_status_when_syncthing_inactive(node1, node2, logger)
+    _verify_status_when_postgres_inactive(node1, node2, logger, node1.client)
+    _verify_status_when_rabbit_inactive(node1, node2, node3, logger,
+                                        node1.client)
 
 
 def _verify_status_when_syncthing_inactive(mgr1, mgr2, logger):
@@ -470,7 +479,7 @@ def _validate_status_when_all_rabbits_inactive(logger, client):
 
 # It can take time for prometheus state to update.
 # Thirty seconds should be much more than enough.
-@retrying.retry(stop_max_attempt_number=15, wait_fixed=2000)
+@retrying.retry(stop_max_attempt_number=30, wait_fixed=2000)
 def _assert_cluster_status(client):
     assert client.cluster_status.get_status()[
         'status'] == ServiceStatus.HEALTHY


### PR DESCRIPTION
We need to add a three-nodes-cluster pytest fixture so it can be used in our system tests.