### PR TITLE
Changes to cfy-cluster-manager tests

### DIFF
--- a/cosmo_tester/config_schemas/cfy_cluster_manager.yaml
+++ b/cosmo_tester/config_schemas/cfy_cluster_manager.yaml
@@ -4,4 +4,4 @@ rpm_path:
   default: 'https://cloudify-release-eu.s3-eu-west-1.amazonaws.com/cloudify/cloudify-cluster-manager/0.0.1/.dev1-release/cloudify-cluster-manager-0.0.1-.dev1.el7.x86_64.rpm'
 manager_install_rpm_path:
   description: The manager-install RPM path to install.
-  default: 'http://repository.cloudifysource.org/cloudify/5.1.0/ga-release/cloudify-manager-install-5.1.0ga.rpm'
+  default: 'http://cloudify-release-eu.s3.amazonaws.com/cloudify/5.2.0/.dev1-release/cloudify-manager-install-5.2.0-.dev1.el7.x86_64.rpm'

--- a/cosmo_tester/config_schemas/cfy_cluster_manager.yaml
+++ b/cosmo_tester/config_schemas/cfy_cluster_manager.yaml
@@ -4,4 +4,4 @@ rpm_path:
   default: 'https://cloudify-release-eu.s3-eu-west-1.amazonaws.com/cloudify/cloudify-cluster-manager/0.0.1/.dev1-release/cloudify-cluster-manager-0.0.1-.dev1.el7.x86_64.rpm'
 manager_install_rpm_path:
   description: The manager-install RPM path to install.
-  default: 'http://cloudify-release-eu.s3.amazonaws.com/cloudify/5.2.0/.dev1-release/cloudify-manager-install-5.2.0-.dev1.el7.x86_64.rpm'
+  default: 'http://repository.cloudifysource.org/cloudify/5.1.0/ga-release/cloudify-manager-install-5.1.0ga.rpm'

--- a/cosmo_tester/test_suites/cluster/cfy_cluster_manager.py
+++ b/cosmo_tester/test_suites/cluster/cfy_cluster_manager.py
@@ -123,7 +123,6 @@ def test_three_nodes_cluster_using_provided_certificates(
             'key_path': join(REMOTE_CERTS_PATH, 'node-{0}.key'.format(i))
         })
 
-    logger.info('Installing cluster')
     _install_cluster(node1, three_nodes_config_dict, test_config, ssh_key,
                      logger)
 
@@ -153,9 +152,6 @@ def test_three_nodes_using_provided_config_files(
         ssh_key, local_certs_path, local_config_files, logger):
     node1, node2, node3 = three_vms
     nodes_list = [node1, node2, node3]
-    logger.info('Creating certificates and passing them to the instances')
-    node1.run_command('mkdir -p {0}'.format(REMOTE_CERTS_PATH))
-    _create_certificates(local_certs_path, nodes_list, pass_certs=True)
 
     _install_cluster_using_provided_config_files(
         nodes_list, three_nodes_config_dict, test_config,
@@ -215,7 +211,7 @@ def _install_cluster_using_provided_config_files(
         nodes_list, three_nodes_config_dict, test_config,
         ssh_key, local_certs_path, local_config_files, logger,
         cause_error=False, override=False):
-    """Install a Cloudify cluster using generated certificates.
+    """Install a Cloudify cluster using generated config files.
 
     In order to do so, the function:
         1. Generates certificates for each node in the `nodes_list`.

--- a/cosmo_tester/test_suites/cluster/cfy_cluster_manager_resources/nine_nodes_config.yaml
+++ b/cosmo_tester/test_suites/cluster/cfy_cluster_manager_resources/nine_nodes_config.yaml
@@ -106,10 +106,6 @@ credentials:
       postgres:
         replicator_password: ''
 
-    db_monitoring:
-      username: ''
-      password: ''
-
   rabbitmq:
     username: ''
     password: ''

--- a/cosmo_tester/test_suites/cluster/cfy_cluster_manager_resources/three_nodes_config.yaml
+++ b/cosmo_tester/test_suites/cluster/cfy_cluster_manager_resources/three_nodes_config.yaml
@@ -67,10 +67,6 @@ credentials:
       postgres:
         replicator_password: ''
 
-    db_monitoring:
-      username: ''
-      password: ''
-
   rabbitmq:
     username: ''
     password: ''


### PR DESCRIPTION
This PR:
1. Removes the db_monitoring from the config files. 
2. Changes minor things in the tests themselves. 