### PR TITLE
RD-838 Fix snapshots inplace upgrade system test

### DIFF
--- a/cosmo_tester/framework/test_hosts.py
+++ b/cosmo_tester/framework/test_hosts.py
@@ -651,6 +651,11 @@ class _CloudifyManager(VM):
                             )
                         )
 
+    @retrying.retry(stop_max_attempt_number=60, wait_fixed=1000)
+    def wait_for_rabbit(self):
+        self._logger.info('Checking rabbit')
+        self.run_command('cfy_manger brokers list')
+
     def enable_nics(self):
         """
         Extra network interfaces need to be manually enabled on the manager

--- a/cosmo_tester/framework/test_hosts.py
+++ b/cosmo_tester/framework/test_hosts.py
@@ -651,11 +651,6 @@ class _CloudifyManager(VM):
                             )
                         )
 
-    @retrying.retry(stop_max_attempt_number=60, wait_fixed=1000)
-    def wait_for_rabbit(self):
-        self._logger.info('Checking rabbit')
-        self.run_command('cfy_manger brokers list')
-
     def enable_nics(self):
         """
         Extra network interfaces need to be manually enabled on the manager

--- a/cosmo_tester/test_suites/snapshots/inplace_upgrade_test.py
+++ b/cosmo_tester/test_suites/snapshots/inplace_upgrade_test.py
@@ -55,7 +55,6 @@ def example(manager_and_vm, ssh_key, tmpdir, logger, test_config):
 
 def test_inplace_upgrade(manager_and_vm,
                          example,
-                         ssh_key,
                          module_tmpdir,
                          logger):
     manager, vm = manager_and_vm
@@ -123,5 +122,6 @@ def test_inplace_upgrade(manager_and_vm,
                 'Agent reconnect retries are up to 30 seconds apart.')
     sleep(50)
     manager.wait_for_manager()
+    manager.wait_for_rabbit()
 
     example.uninstall()

--- a/cosmo_tester/test_suites/snapshots/inplace_upgrade_test.py
+++ b/cosmo_tester/test_suites/snapshots/inplace_upgrade_test.py
@@ -118,10 +118,9 @@ def test_inplace_upgrade(manager_and_vm,
         if not reboot_performed:
             raise RuntimeError('Expected reboot did not happen.')
 
-    logger.info('Waiting 50 seconds for agents to reconnect. '
+    logger.info('Waiting 60 seconds for agents to reconnect. '
                 'Agent reconnect retries are up to 30 seconds apart.')
-    sleep(50)
+    sleep(60)
     manager.wait_for_manager()
-    manager.wait_for_rabbit()
 
     example.uninstall()


### PR DESCRIPTION
The snapshot inplace upgrade test fails while trying to uninstall the example deployment. This happens, as far as I understand, because the uninstall task is sent to the rabbitmq before it is initialized.
Waiting for the rabbitmq to be alive, should fix it -> well, it didn't.
Giving the manager more time to initialize (by increasing the sleep time) worked. 