### PR TITLE
RD-1090 Update cfy-cluster-manager config files test

### DIFF
--- a/cosmo_tester/config_schemas/cfy_cluster_manager.yaml
+++ b/cosmo_tester/config_schemas/cfy_cluster_manager.yaml
@@ -1,7 +1,7 @@
 namespace: cfy_cluster_manager
 rpm_path:
   description: The cfy_cluster_manager RPM path to install.
-  default: 'https://cloudify-release-eu.s3-eu-west-1.amazonaws.com/cloudify/cloudify-cluster-manager/1.0.7/.dev1-release/cloudify-cluster-manager-1.0.7-.dev1.el7.x86_64.rpm'
+  default: 'https://cloudify-release-eu.s3-eu-west-1.amazonaws.com/cloudify/cloudify-cluster-manager/1.0.6/ga-release/cloudify-cluster-manager-1.0.6-ga.el7.x86_64.rpm'
 manager_install_rpm_path:
   description: The manager-install RPM path to install.
   default: 'http://cloudify-release-eu.s3.amazonaws.com/cloudify/5.2.0/.dev1-release/cloudify-manager-install-5.2.0-.dev1.el7.x86_64.rpm'

--- a/cosmo_tester/test_suites/cluster/cfy_cluster_manager_test.py
+++ b/cosmo_tester/test_suites/cluster/cfy_cluster_manager_test.py
@@ -127,7 +127,7 @@ def test_three_nodes_cluster_using_provided_certificates(
         key_path_in_use = '/etc/cloudify/ssl/cloudify_internal_key.pem'
 
         assert (local_node_cert_path.read_text() ==
-                node.get_remote_file_content(cert_path_in_use))
+                node.get_remote_file_cNontent(cert_path_in_use))
 
         assert (local_node_key_path.read_text() ==
                 node.get_remote_file_content(key_path_in_use))
@@ -147,23 +147,26 @@ def test_three_nodes_using_provided_config_files(
         ssh_key, local_certs_path, local_config_files, logger)
 
     logger.info('Asserting config_files')
-    base_cfy_dir = '/etc/cloudify'
+    cluster_manager_config_files = '/tmp/cloudify_cluster_manager/config_files'
     for i, node in enumerate(nodes_list, start=1):
         logger.info('Asserting config.yaml files for %s', 'node-{0}'.format(i))
 
         assert (node.local_manager_config_path.read_text() ==
                 node.get_remote_file_content(
-                    join(base_cfy_dir, node.local_manager_config_path.name))
+                    join(cluster_manager_config_files,
+                         node.local_manager_config_path.name))
                 )
 
         assert (node.local_postgresql_config_path.read_text() ==
                 node.get_remote_file_content(
-                    join(base_cfy_dir, node.local_postgresql_config_path.name))
+                    join(cluster_manager_config_files,
+                         node.local_postgresql_config_path.name))
                 )
 
         assert (node.local_rabbitmq_config_path.read_text() ==
                 node.get_remote_file_content(
-                    join(base_cfy_dir, node.local_rabbitmq_config_path.name))
+                    join(cluster_manager_config_files,
+                         node.local_rabbitmq_config_path.name))
                 )
 
 


### PR DESCRIPTION
[This change to cloudify-cluster-manager](https://github.com/cloudify-cosmo/cloudify-cluster-manager/pull/69) copies the config.yaml file at the end of each service's installation to the service's config.yaml file. This caused `cosmo_tester/test_suites/cluster/cfy_cluster_manager_test.py::test_three_nodes_using_provided_config_files` to fail since it was asserting that the services' config files are equal to the ones that were provided (which was not true anymore). 

This PR fixes it by changing the assertion to assert that the provided config files are equal to the services' config files at /tmp/cloudify_cluster_manager/config_files which are used for the installation, and are not being overriden.