### PR TITLE
RD-1284 Stop triggering deployment creation environment

### DIFF
--- a/cosmo_tester/framework/examples.py
+++ b/cosmo_tester/framework/examples.py
@@ -119,21 +119,6 @@ class BaseExample(object):
             self.logger.info('Deployments for tenant {}'.format(self.tenant))
             for deployment in self.manager.client.deployments.list():
                 self.logger.info(deployment['id'])
-        if wait:
-            self.wait_for_deployment_environment_creation()
-
-    def wait_for_deployment_environment_creation(self):
-        self.logger.info('Waiting for deployment env creation.')
-        while True:
-            with set_client_tenant(self.manager.client, self.tenant):
-                executions = self.manager.client.executions.list(
-                    _include=['status'],
-                    deployment_id=self.deployment_id,
-                    workflow_id='create_deployment_environment',
-                )
-                if all(exc['status'] == 'terminated' for exc in executions):
-                    break
-        self.logger.info('Deployment env created.')
 
     def install(self):
         self.logger.info('Installing deployment...')

--- a/cosmo_tester/framework/test_hosts.py
+++ b/cosmo_tester/framework/test_hosts.py
@@ -856,24 +856,15 @@ class Hosts(object):
             cancelled = []
             execs = self._infra_client.executions.list()
             for execution in execs:
-                if execution['workflow_id'] != (
-                    'create_deployment_environment'
-                ):
-                    self._logger.info(
-                        'Ensuring %s (%s) is not running.',
-                        execution['id'],
-                        execution['workflow_id'],
-                    )
-                    self._infra_client.executions.cancel(
-                        execution['id'], force=True, kill=True
-                    )
-                    cancelled.append(execution['id'])
-                else:
-                    self._logger.info(
-                        'Skipping %s (%s).',
-                        execution['id'],
-                        execution['workflow_id'],
-                    )
+                self._logger.info(
+                    'Ensuring %s (%s) is not running.',
+                    execution['id'],
+                    execution['workflow_id'],
+                )
+                self._infra_client.executions.cancel(
+                    execution['id'], force=True, kill=True
+                )
+                cancelled.append(execution['id'])
 
             cancel_complete = []
             for execution_id in cancelled:

--- a/cosmo_tester/framework/util.py
+++ b/cosmo_tester/framework/util.py
@@ -567,23 +567,6 @@ def create_deployment(client, blueprint_id, deployment_id, logger,
         skip_plugins_validation=skip_plugins_validation,
     )
 
-    logger.info('Waiting for deployment env creation for %s',
-                deployment_id)
-    executions = client.executions.list(deployment_id=deployment_id)
-    for execution in executions:
-        if execution.workflow_id == 'create_deployment_environment':
-            wait_for_execution(
-                client,
-                execution,
-                logger,
-            )
-            return
-    raise DeploymentCreationError(
-        'Deployment environment creation workflow not found for {}'.format(
-            deployment_id,
-        )
-    )
-
 
 class DeploymentDeletionError(Exception):
     """Deployment deletion failed."""

--- a/cosmo_tester/test_suites/summary/summary_test.py
+++ b/cosmo_tester/test_suites/summary/summary_test.py
@@ -400,10 +400,8 @@ def test_subfield_summary_executions(prepared_manager):
         {
             u'by workflow_id': [
                 {
-                    u'executions': 1,
-                    u'workflow_id': u'create_deployment_environment'
-                },
-                {u'executions': 1, u'workflow_id': u'install'}
+                    u'executions': 1, u'workflow_id': u'install'
+                }
             ],
             u'deployment_id': u'multivm0',
             u'executions': 2
@@ -411,10 +409,8 @@ def test_subfield_summary_executions(prepared_manager):
         {
             u'by workflow_id': [
                 {
-                    u'executions': 1,
-                    u'workflow_id': u'create_deployment_environment'
-                },
-                {u'executions': 1, u'workflow_id': u'install'}
+                    u'executions': 1, u'workflow_id': u'install'
+                }
             ],
             u'deployment_id': u'relations0',
             u'executions': 2
@@ -422,10 +418,8 @@ def test_subfield_summary_executions(prepared_manager):
         {
             u'by workflow_id': [
                 {
-                    u'executions': 1,
-                    u'workflow_id': u'create_deployment_environment'
-                },
-                {u'executions': 1, u'workflow_id': u'install'}
+                    u'executions': 1, u'workflow_id': u'install'
+                }
             ],
             u'deployment_id': u'relations1',
             u'executions': 2
@@ -433,10 +427,8 @@ def test_subfield_summary_executions(prepared_manager):
         {
             u'by workflow_id': [
                 {
-                    u'executions': 1,
-                    u'workflow_id': u'create_deployment_environment'
-                },
-                {u'executions': 1, u'workflow_id': u'install'}
+                    u'executions': 1, u'workflow_id': u'install'
+                }
             ],
             u'deployment_id': u'relations2',
             u'executions': 2
@@ -444,10 +436,8 @@ def test_subfield_summary_executions(prepared_manager):
         {
             u'by workflow_id': [
                 {
-                    u'executions': 1,
-                    u'workflow_id': u'create_deployment_environment'
-                },
-                {u'executions': 1, u'workflow_id': u'install'}
+                    u'executions': 1, u'workflow_id': u'install'
+                }
             ],
             u'deployment_id': u'small0',
             u'executions': 2
@@ -455,10 +445,8 @@ def test_subfield_summary_executions(prepared_manager):
         {
             u'by workflow_id': [
                 {
-                    u'executions': 1,
-                    u'workflow_id': u'create_deployment_environment'
-                },
-                {u'executions': 1, u'workflow_id': u'install'}
+                    u'executions': 1, u'workflow_id': u'install'
+                }
             ],
             u'deployment_id': u'small1',
             u'executions': 2


### PR DESCRIPTION
Update the systems tests framework and any other tests that still depending on the deployment creation environment as we no longer have a workflow on the core when create a deployment 