### PR TITLE
Revert to older requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,151 +4,65 @@
 #
 #    pip-compile --output-file=requirements.txt requirements.in setup.py
 #
-apipkg==1.5
-    # via execnet
-appdirs==1.4.4
-    # via virtualenv
-attrs==20.3.0
-    # via pytest
-bcrypt==3.2.0
-    # via paramiko
-bottle==0.12.18
-    # via cloudify-common
-certifi==2019.11.28
-    # via requests
-cffi==1.14.4
-    # via
-    #   bcrypt
-    #   cryptography
-    #   pynacl
-chardet==3.0.4
-    # via requests
-https://github.com/cloudify-cosmo/cloudify-common/archive/5.2.0-build.zip#egg=cloudify-common[dispatcher]
-    # via -r requirements.in
-cryptography==3.3.1
-    # via
-    #   paramiko
-    #   requests-ntlm
-decorator==4.4.2
-    # via networkx
-distlib==0.3.1
-    # via virtualenv
-execnet==1.8.0
-    # via pytest-xdist
-fabric==2.6.0
-    # via cloudify-system-tests (setup.py)
-fasteners==0.13.0
-    # via cloudify-common
-filelock==3.0.12
-    # via virtualenv
-idna==2.9
-    # via requests
-importlib-metadata==3.4.0
-    # via
-    #   pluggy
-    #   pytest
-    #   virtualenv
-importlib-resources==5.1.0
-    # via virtualenv
-iniconfig==1.1.1
-    # via pytest
-invoke==1.5.0
-    # via fabric
-jinja2==2.10.3
-    # via
-    #   cloudify-common
-    #   cloudify-system-tests (setup.py)
-markupsafe==1.1.1
-    # via jinja2
-monotonic==1.5
-    # via fasteners
-networkx==1.9.1
-    # via cloudify-common
-ntlm-auth==1.5.0
-    # via requests-ntlm
-packaging==20.9
-    # via pytest
-paramiko==2.7.2
-    # via fabric
-path.py==12.5.0
-    # via cloudify-system-tests (setup.py)
-path==15.1.0
-    # via path.py
-pathlib2==2.3.5
-    # via fabric
-pika==1.1.0
-    # via cloudify-common
-pluggy==0.13.1
-    # via pytest
-proxy_tools==0.1.0
-    # via cloudify-common
-py==1.10.0
-    # via
-    #   pytest
-    #   pytest-forked
-pycparser==2.20
-    # via cffi
-pynacl==1.4.0
-    # via paramiko
-pyparsing==2.4.7
-    # via packaging
-pytest-forked==1.3.0
-    # via pytest-xdist
-pytest-xdist==2.2.0
-    # via cloudify-system-tests (setup.py)
-pytest==6.2.2
-    # via
-    #   cloudify-system-tests (setup.py)
-    #   pytest-forked
-    #   pytest-xdist
-pywinrm==0.4.1
-    # via cloudify-system-tests (setup.py)
-pyyaml==5.3.1
-    # via
-    #   cloudify-common
-    #   cloudify-system-tests (setup.py)
-requests-ntlm==1.1.0
-    # via pywinrm
-requests==2.23.0
-    # via
-    #   cloudify-common
-    #   cloudify-system-tests (setup.py)
-    #   pywinrm
-    #   requests-ntlm
-    #   requests-toolbelt
-requests_toolbelt==0.8.0
-    # via cloudify-common
-retrying==1.3.3
-    # via
-    #   cloudify-common
-    #   cloudify-system-tests (setup.py)
-six==1.14.0
-    # via
-    #   bcrypt
-    #   cryptography
-    #   fasteners
-    #   pathlib2
-    #   pynacl
-    #   pywinrm
-    #   retrying
-    #   virtualenv
-toml==0.10.2
-    # via pytest
-typing-extensions==3.7.4.3
-    # via importlib-metadata
-urllib3==1.25.8
-    # via requests
-virtualenv==20.4.2
-    # via wagon
-wagon[venv]==0.11.0
-    # via
-    #   cloudify-common
-    #   cloudify-system-tests (setup.py)
-wheel==0.29.0
-    # via wagon
-xmltodict==0.12.0
-    # via pywinrm
-zipp==3.4.0
-    # via
-    #   importlib-metadata
-    #   importlib-resources
+apipkg==1.5               # via execnet
+atomicwrites==1.4.0       # via pytest
+attrs==19.3.0             # via pytest
+backports.os==0.1.1       # via path.py
+bcrypt==3.1.7             # via paramiko
+bottle==0.12.18           # via cloudify-common
+certifi==2019.11.28       # via requests
+cffi==1.14.0              # via bcrypt, cryptography, pynacl
+chardet==3.0.4            # via requests
+https://github.com/cloudify-cosmo/cloudify-common/archive/5.2.0-build.zip#egg=cloudify-common[dispatcher]  # via -r requirements.in
+configparser==4.0.2       # via importlib-metadata
+contextlib2==0.6.0.post1  # via importlib-metadata, zipp
+cryptography==2.9.2       # via paramiko, requests-ntlm
+decorator==4.4.2          # via networkx
+enum34==1.1.10            # via cryptography
+execnet==1.7.1            # via pytest-xdist
+fabric==2.5.0             # via cloudify-system-tests (setup.py)
+funcsigs==1.0.2           # via pytest
+future==0.18.2            # via backports.os
+idna==2.9                 # via requests
+importlib-metadata==1.6.0  # via path.py, pluggy, pytest
+invoke==1.4.1             # via fabric
+ipaddress==1.0.19         # via cryptography
+jinja2==2.11.2            # via cloudify-common, cloudify-system-tests (setup.py)
+markupsafe==1.1.1         # via jinja2
+more-itertools==5.0.0     # via pytest
+networkx==1.9.1           # via cloudify-common
+ntlm-auth==1.4.0          # via requests-ntlm
+packaging==20.3           # via pytest
+paramiko==2.7.1           # via fabric
+path.py==11.5.2           # via cloudify-system-tests (setup.py)
+pathlib2==2.3.5           # via importlib-metadata, pytest
+pika==0.11.2              # via cloudify-common
+pluggy==0.13.1            # via pytest
+ply==3.11                 # via pysmi
+proxy_tools==0.1.0        # via cloudify-common
+py==1.8.1                 # via pytest
+pyasn1==0.4.8             # via pysnmp
+pycparser==2.20           # via cffi
+pycryptodomex==3.9.8      # via pysnmp
+pynacl==1.3.0             # via paramiko
+pyparsing==2.4.7          # via packaging
+pysmi==0.3.4              # via pysnmp
+pysnmp==4.4.5             # via cloudify-common
+pytest-forked==1.1.3      # via pytest-xdist
+pytest-xdist==1.32.0      # via cloudify-system-tests (setup.py)
+pytest==4.6.10            # via cloudify-system-tests (setup.py), pytest-forked, pytest-xdist
+pywinrm==0.4.1            # via cloudify-system-tests (setup.py)
+pyyaml==5.3.1             # via cloudify-common, cloudify-system-tests (setup.py)
+requests-ntlm==1.1.0      # via pywinrm
+requests==2.23.0          # via cloudify-common, cloudify-system-tests (setup.py), pywinrm, requests-ntlm, requests-toolbelt
+requests_toolbelt==0.8.0  # via cloudify-common
+retrying==1.3.3           # via cloudify-common, cloudify-system-tests (setup.py)
+scandir==1.10.0           # via pathlib2
+six==1.14.0               # via bcrypt, cryptography, more-itertools, packaging, pathlib2, pynacl, pytest, pytest-xdist, pywinrm, retrying
+urllib3==1.25.8           # via requests
+virtualenv==15.1.0        # via wagon
+wagon[venv]==0.6.3        # via cloudify-system-tests (setup.py)
+wcwidth==0.1.9            # via pytest
+wheel==0.29.0             # via wagon
+xmltodict==0.12.0         # via pywinrm
+zipp==1.2.0               # via importlib-metadata


### PR DESCRIPTION
This reverts to the previous reqs.txt, which are compatible
with py2.
The rewritten reqs.txt would've been only compatible with py3.
But we still run tests on py2 on jenkins

The change between this commit and master is that I've of course kept
the 5.2.0-build.zip for cloudify-common