### PR TITLE
Rd 717 Make windows agent tests able to run

### DIFF
--- a/cosmo_tester/config_schemas/platform_aws.yaml
+++ b/cosmo_tester/config_schemas/platform_aws.yaml
@@ -45,7 +45,7 @@ centos_7_image:
   default: ami-04f5641b0d178a27a
 windows_2012_image:
   description: Image to use for Windows 2012 on this platform.
-  default: ami-05f34bb57ea1a77ad
+  default: ami-0881437e28c7f4afe
 named_image_owners:
   description: Comma separated list of allowed owners for images not referred to by AMI ID.
   default: "919239153674"

--- a/cosmo_tester/framework/test_hosts.py
+++ b/cosmo_tester/framework/test_hosts.py
@@ -554,12 +554,13 @@ $user.SetInfo()""".format(fw_cmd=add_firewall_cmd,
         ca_cert_path = '~/.cloudify-test-ca/ca.crt'
 
         with self.ssh() as ssh:
-            self._logger.info('Making sure blackbox_exporter is running '
-                              '(if applicable)')
-            # Because the cert replacement tries to restart it, and sometimes
-            # it isn't running which gets us stuck in a really slow and boring
-            # loop.
-            ssh.run('sudo supervisorctl start blackbox_exporter || true')
+            self._logger.info('Making sure configuration is finished.')
+            # It turns out that running cert replacement while the starter is
+            # running causes really fun errors!
+            # Also, starter is named such that wait-for-starter doesn't work.
+            # So, since this is only touched once configuration is done, we
+            # will use it.
+            ssh.run('test -f /etc/cloudify/.configured/manager-service')
 
             self._logger.info('Generating certificates including public IP')
             ips = [self.private_ip_address, self.ip_address]

--- a/cosmo_tester/framework/test_hosts.py
+++ b/cosmo_tester/framework/test_hosts.py
@@ -48,7 +48,6 @@ class VM(object):
         self._test_config = test_config
         self.windows = 'windows' in image_type
         self._tmpdir_base = None
-        self.api_version = None
         self.bootstrappable = bootstrappable
         self.image_type = image_type
         self.is_manager = self._is_manager_image_type()
@@ -101,7 +100,6 @@ class VM(object):
                 },
             }
             self.install_config = copy.deepcopy(self.basic_install_config)
-            self.api_version = 'v3.1'
         if self.windows:
             self.prepare_for_windows()
         else:
@@ -618,7 +616,6 @@ $user.SetInfo()""".format(fw_cmd=add_firewall_cmd,
                     tenant=test_mgr_conf['tenant'],
                     cert=self._tmpdir / self.server_id + '_api.crt',
                     protocol='https',
-                    api_version=self.api_version,
                 )
             raise
 
@@ -1228,14 +1225,13 @@ class Hosts(object):
                         networks[net_name] = str(ip)
                         break
 
-        if hasattr(instance, 'api_version'):
+        if instance.is_manager:
             test_mgr_conf = self._test_config['test_manager']
             rest_client = util.create_rest_client(
                 public_ip_address,
                 username=test_mgr_conf['username'],
                 password=test_mgr_conf['password'],
                 tenant=test_mgr_conf['tenant'],
-                api_version=instance.api_version,
             )
         else:
             rest_client = None

--- a/cosmo_tester/framework/test_hosts.py
+++ b/cosmo_tester/framework/test_hosts.py
@@ -5,7 +5,9 @@ import functools
 import hashlib
 import json
 import os
+import random
 import re
+import string
 import socket
 import subprocess
 import time
@@ -133,7 +135,11 @@ class VM(object):
     def prepare_for_windows(self):
         """Prepare this VM to be created as a windows VM."""
         add_firewall_cmd = "&netsh advfirewall firewall add rule"
-        password = 'AbCdEfG123456!'
+        password = ''.join(random.choice(string.ascii_letters + string.digits)
+                           for _ in range(16))
+        # To meet complexity requirements- the above should be hard enough to
+        # crack for a short lived test VM
+        password += '!'
 
         self.enable_ssh_wait = False
         self.restservice_expected = False

--- a/cosmo_tester/resources/infrastructure_blueprints/aws/infrastructure-multi-net.yaml
+++ b/cosmo_tester/resources/infrastructure_blueprints/aws/infrastructure-multi-net.yaml
@@ -204,6 +204,16 @@ node_templates:
         IpRanges:
         - CidrIp: 0.0.0.0/0
       - IpProtocol: tcp
+        FromPort: 3389
+        ToPort: 3389
+        IpRanges:
+        - CidrIp: 0.0.0.0/0
+      - IpProtocol: tcp
+        FromPort: 5985
+        ToPort: 5985
+        IpRanges:
+        - CidrIp: 0.0.0.0/0
+      - IpProtocol: tcp
         FromPort: 1
         ToPort: 65535
         IpRanges:

--- a/cosmo_tester/resources/infrastructure_blueprints/aws/infrastructure.yaml
+++ b/cosmo_tester/resources/infrastructure_blueprints/aws/infrastructure.yaml
@@ -120,6 +120,16 @@ node_templates:
         IpRanges:
         - CidrIp: 0.0.0.0/0
       - IpProtocol: tcp
+        FromPort: 3389
+        ToPort: 3389
+        IpRanges:
+        - CidrIp: 0.0.0.0/0
+      - IpProtocol: tcp
+        FromPort: 5985
+        ToPort: 5985
+        IpRanges:
+        - CidrIp: 0.0.0.0/0
+      - IpProtocol: tcp
         FromPort: 1
         ToPort: 65535
         IpRanges:

--- a/cosmo_tester/resources/infrastructure_blueprints/aws/vm-multi-net.yaml
+++ b/cosmo_tester/resources/infrastructure_blueprints/aws/vm-multi-net.yaml
@@ -41,6 +41,7 @@ node_templates:
         InstanceType: { get_input: flavor }
         kwargs:
           KeyName: { get_input: test_infrastructure_name }
+          UserData: { get_input: userdata }
       client_config: *client_config
       Tags:
         - Key: Name

--- a/cosmo_tester/resources/infrastructure_blueprints/aws/vm.yaml
+++ b/cosmo_tester/resources/infrastructure_blueprints/aws/vm.yaml
@@ -41,6 +41,7 @@ node_templates:
         InstanceType: { get_input: flavor }
         kwargs:
           KeyName: { get_input: test_infrastructure_name }
+          UserData: { get_input: userdata }
       client_config: *client_config
       Tags:
         - Key: Name

--- a/cosmo_tester/test_suites/cluster/conftest.py
+++ b/cosmo_tester/test_suites/cluster/conftest.py
@@ -606,7 +606,6 @@ def _bootstrap_manager_node(node, mgr_num, dbs, brokers, skip_bootstrap_list,
         username=test_config['test_manager']['username'],
         password=test_config['test_manager']['password'],
         tenant=test_config['test_manager']['tenant'],
-        api_version=node.api_version,
         cert=node.local_ca,
         protocol='https',
     )


### PR DESCRIPTION
They don't pass, but they can at least run. The failures now are either from the agent itself or from the test code, with reasonably suspicion being cast one way or the other when I run more agent tests.