### PR TITLE
Remove RHEL 6 from testing

### DIFF
--- a/cosmo_tester/config_schemas/platform_aws.yaml
+++ b/cosmo_tester/config_schemas/platform_aws.yaml
@@ -34,9 +34,6 @@ rhel_8_image:
 rhel_7_image:
   description: Image to use for RHEL 7 on this platform.
   default: ami-020e14de09d1866b4
-rhel_6_image:
-  description: Image to use for RHEL 6 on this platform.
-  default: ami-0803077e5450a1a9e
 centos_8_image:
   description: Image to use for Centos 8 on this platform.
   default: ami-0a75a5a43b05b4d5f

--- a/cosmo_tester/config_schemas/platform_openstack.yaml
+++ b/cosmo_tester/config_schemas/platform_openstack.yaml
@@ -35,9 +35,6 @@ rhel_8_image:
 rhel_7_image:
   description: Image to use for RHEL 7 on this platform.
   default: rhel7.6-py3
-rhel_6_image:
-  description: Image to use for RHEL 6 on this platform.
-  default: rhel-guest-image-6.9-120.x86_64.qcow2
 centos_8_image:
   description: Image to use for Centos 8 on this platform.
   default: CentOS-8_1-x86_64-GenericCloud

--- a/cosmo_tester/config_schemas/test_os_usernames.yaml
+++ b/cosmo_tester/config_schemas/test_os_usernames.yaml
@@ -5,9 +5,6 @@ rhel_8:
 rhel_7:
   description: Username for RHEL 7 test VMs.
   default: cloud-user
-rhel_6:
-  description: Username for RHEL 6 test VMs.
-  default: cloud-user
 ubuntu_14_04:
   description: Username for Ubuntu 14.04 test VMs.
   default: ubuntu

--- a/cosmo_tester/test_suites/agent/test_reboot.py
+++ b/cosmo_tester/test_suites/agent/test_reboot.py
@@ -11,7 +11,6 @@ from cosmo_tester.test_suites.agent import get_test_prerequisites
     'ubuntu_16_04',
     'centos_8',
     'centos_7',
-    'rhel_6',
     'rhel_7',
     'rhel_8',
     'windows_2012',


### PR DESCRIPTION
We can't build RHEL 6 agents any more so let's not test them.