### PR TITLE
Remove 5.1.0 from upgrade base versions

### DIFF
--- a/cosmo_tester/framework/constants.py
+++ b/cosmo_tester/framework/constants.py
@@ -11,3 +11,9 @@ SUPPORTED_RELEASES = [
     '5.2.1',
     'master',
 ]
+
+SUPPORTED_FOR_RPM_UPGRADE = [
+    version + '-ga'
+    for version in SUPPORTED_RELEASES
+    if version not in ('master', '5.0.5', '5.1.0')
+]

--- a/cosmo_tester/test_suites/cluster/cfy_cluster_manager_shared.py
+++ b/cosmo_tester/test_suites/cluster/cfy_cluster_manager_shared.py
@@ -5,15 +5,9 @@ import pkg_resources
 from retrying import retry
 import yaml
 
-from cosmo_tester.framework.constants import SUPPORTED_RELEASES
 from cosmo_tester.framework import util
 
 
-BASE_VERSIONS = [
-    version + '-ga'
-    for version in SUPPORTED_RELEASES
-    if version not in ('master', '5.0.5', '5.1.0')
-]
 CLUSTER_MANAGER_RESOURCES_PATH = pkg_resources.resource_filename(
     'cosmo_tester', 'test_suites/cluster/cfy_cluster_manager_resources')
 REMOTE_CLUSTER_CONFIG_PATH = '/tmp/cfy_cluster_config.yaml'

--- a/cosmo_tester/test_suites/cluster/cfy_cluster_manager_shared.py
+++ b/cosmo_tester/test_suites/cluster/cfy_cluster_manager_shared.py
@@ -12,7 +12,7 @@ from cosmo_tester.framework import util
 BASE_VERSIONS = [
     version + '-ga'
     for version in SUPPORTED_RELEASES
-    if version not in ('master', '5.0.5')
+    if version not in ('master', '5.0.5', '5.1.0')
 ]
 CLUSTER_MANAGER_RESOURCES_PATH = pkg_resources.resource_filename(
     'cosmo_tester', 'test_suites/cluster/cfy_cluster_manager_resources')

--- a/cosmo_tester/test_suites/cluster/compact_cfy_cluster_manager_upgrade_test.py
+++ b/cosmo_tester/test_suites/cluster/compact_cfy_cluster_manager_upgrade_test.py
@@ -1,12 +1,10 @@
 import pytest
 
-from .cfy_cluster_manager_shared import (
-    BASE_VERSIONS,
-    _cluster_upgrade_test,
-)
+from .cfy_cluster_manager_shared import _cluster_upgrade_test
+from cosmo_tester.framework.constants import SUPPORTED_FOR_RPM_UPGRADE
 
 
-@pytest.mark.parametrize('base_version', BASE_VERSIONS)
+@pytest.mark.parametrize('base_version', SUPPORTED_FOR_RPM_UPGRADE)
 def test_three_nodes_cluster_upgrade(base_version, three_vms, test_config,
                                      ssh_key, logger):
     """Tests the command cfy_cluster_manager upgrade on a 3 nodes cluster."""

--- a/cosmo_tester/test_suites/cluster/full_cfy_cluster_manager_upgrade_test.py
+++ b/cosmo_tester/test_suites/cluster/full_cfy_cluster_manager_upgrade_test.py
@@ -1,12 +1,10 @@
 import pytest
 
-from .cfy_cluster_manager_shared import (
-    BASE_VERSIONS,
-    _cluster_upgrade_test,
-)
+from .cfy_cluster_manager_shared import _cluster_upgrade_test
+from cosmo_tester.framework.constants import SUPPORTED_FOR_RPM_UPGRADE
 
 
-@pytest.mark.parametrize('base_version', BASE_VERSIONS)
+@pytest.mark.parametrize('base_version', SUPPORTED_FOR_RPM_UPGRADE)
 def test_nine_nodes_cluster_upgrade(base_version, nine_vms, test_config,
                                     ssh_key, logger):
     """Tests the command cfy_cluster_manager upgrade on a 9 nodes cluster."""

--- a/cosmo_tester/test_suites/general/cfy_manager_test.py
+++ b/cosmo_tester/test_suites/general/cfy_manager_test.py
@@ -1,7 +1,7 @@
 import json
 import pytest
 
-from cosmo_tester.framework.constants import SUPPORTED_RELEASES
+from cosmo_tester.framework.constants import SUPPORTED_FOR_RPM_UPGRADE
 from cosmo_tester.framework.examples import get_example_deployment
 from cosmo_tester.framework.test_hosts import Hosts, VM
 from cosmo_tester.framework.util import (get_manager_install_version,
@@ -41,14 +41,7 @@ with open('%s', 'w') as f:
 ''' % MQ_PASSWORDS_PATH
 
 
-BASE_VERSIONS = [
-    version
-    for version in SUPPORTED_RELEASES
-    if version not in ('master', '5.0.5')
-]
-
-
-@pytest.fixture(scope='function', params=BASE_VERSIONS)
+@pytest.fixture(scope='function', params=SUPPORTED_FOR_RPM_UPGRADE)
 def base_manager(request, ssh_key, module_tmpdir, test_config, logger):
     hosts = Hosts(ssh_key, module_tmpdir, test_config, logger, request)
     hosts.instances[0] = VM(request.param, test_config)


### PR DESCRIPTION
According to Ofer, we don't support upgrading from v5.1.0 using `cfy_manager upgrade`, so we should also remove it from the tests. 