### PR TITLE
RD-858 test_inplace_restore: wait_for_manager after snap-restore

### DIFF
--- a/cosmo_tester/test_suites/snapshots/inplace_restore_test.py
+++ b/cosmo_tester/test_suites/snapshots/inplace_restore_test.py
@@ -113,8 +113,8 @@ def test_inplace_restore(manager_and_vm,
             raise RuntimeError('Expected reboot did not happen.')
     manager.wait_for_manager()
 
-    logger.info('Waiting 60 seconds for agents to reconnect. '
+    logger.info('Waiting 35 seconds for agents to reconnect. '
                 'Agent reconnect retries are up to 30 seconds apart.')
-    sleep(60)
+    sleep(35)
 
     example.uninstall()

--- a/cosmo_tester/test_suites/snapshots/inplace_restore_test.py
+++ b/cosmo_tester/test_suites/snapshots/inplace_restore_test.py
@@ -111,10 +111,10 @@ def test_inplace_restore(manager_and_vm,
             )
         if not reboot_performed:
             raise RuntimeError('Expected reboot did not happen.')
+    manager.wait_for_manager()
 
     logger.info('Waiting 60 seconds for agents to reconnect. '
                 'Agent reconnect retries are up to 30 seconds apart.')
     sleep(60)
-    manager.wait_for_manager()
 
     example.uninstall()


### PR DESCRIPTION
After restoring the snapshot, we wait for the manager to come back
up, because the snapshot-restore includes a reboot.

Only THEN we wait for agents. Why would we wait for agents before
the manager was up?

The order of operations is:
1. snap-restore
2. reboot
3. wait for manager to come back up
4. wait for agents to reconnect

Before this change, 3 and 4 were swapped