### PR TITLE
RD-2468 Always bootstrap test nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ For UI tests: cloudify-blueprint-composer, cloudify-stage
 They are expected to exist in the same directory that the cloudify-system-tests directory exists, but this can be changed in the config.
 
 The test framework assumes that manager images will exist, as defined in the schema.
-To see expected images, look in the config under manager_image_names_centos and manager_image_names_rhel.
+To see expected image name structure, look in the config under manager_image_names.
 
 To see the schema including default values, run:
 ```bash

--- a/cosmo_tester/config_schemas/manager_image_names.yaml
+++ b/cosmo_tester/config_schemas/manager_image_names.yaml
@@ -1,0 +1,7 @@
+namespace: manager_image_names
+centos:
+  description: Template of name of centos manager installer image (for bootstrap or cluster) to test. The testing version will be filled in based on testing_version (config parameter) or supported manager versions in tests.
+  default: cfy-installer-premium-{testing_version}
+rhel:
+  description: Template of name of RHEL manager installer image (for bootstrap or cluster) to test. The testing version will be filled in based on testing_version (config parameter) or supported manager versions in tests.
+  default: cfy-installer-premium-{testing_version}-rhel

--- a/cosmo_tester/config_schemas/manager_image_names_centos.yaml
+++ b/cosmo_tester/config_schemas/manager_image_names_centos.yaml
@@ -1,7 +1,0 @@
-namespace: manager_image_names_centos
-manager:
-  description: Template of name of manager image to test. The testing version will be filled in based on testing_version (config parameter) or supported manager versions in tests.
-  default: cloudify-manager-premium-{testing_version}
-installer:
-  description: Template of name of manager installer image (for bootstrap or cluster) to test. The testing version will be filled in based on testing_version (config parameter) or supported manager versions in tests.
-  default: cfy-installer-premium-{testing_version}

--- a/cosmo_tester/config_schemas/manager_image_names_rhel.yaml
+++ b/cosmo_tester/config_schemas/manager_image_names_rhel.yaml
@@ -1,7 +1,0 @@
-namespace: manager_image_names_rhel
-manager:
-  description: Template of name of manager image to test. The testing version will be filled in based on testing_version (config parameter) or supported manager versions in tests.
-  default: cloudify-manager-premium-{testing_version}-rhel
-installer:
-  description: Template of name of manager installer image (for bootstrap or cluster) to test. The testing version will be filled in based on testing_version (config parameter) or supported manager versions in tests.
-  default: cfy-installer-premium-{testing_version}-rhel

--- a/cosmo_tester/test_suites/cluster/conftest.py
+++ b/cosmo_tester/test_suites/cluster/conftest.py
@@ -145,8 +145,8 @@ def _get_hosts(ssh_key, module_tmpdir, test_config, logger, request,
                # High security will pre-set all certs (not just required ones)
                # and use postgres client certs.
                pre_cluster_rabbit=False, high_security=True, extra_node=None,
-               use_hostnames=False, three_nodes_cluster=False, bootstrap=True,
-               installer_image_name=None):
+               use_hostnames=False, three_nodes_cluster=False,
+               bootstrap=True):
     number_of_cluster_instances = (
         3 if three_nodes_cluster else broker_count + db_count + manager_count)
     has_extra_node = (1 if extra_node else 0)
@@ -170,13 +170,6 @@ def _get_hosts(ssh_key, module_tmpdir, test_config, logger, request,
 
         for node in hosts.instances:
             node.verify_services_are_running = skip
-
-        if installer_image_name:
-            distro = test_config['test_manager']['distro']
-            image_names = 'manager_image_names_{}'.format(distro)
-            for i in range(number_of_cluster_instances):
-                hosts.instances[i].image_name = test_config[image_names][
-                    installer_image_name]
 
         hosts.create()
 


### PR DESCRIPTION
Given that the starter service just does a configure anyway, this is
effectively doing the same thing, but reducing the code paths.

Additionally, this means that we don't need to replace certs any more
because we are bootstrapping the node with the right IPs on the certs.