### PR TITLE
RD-2527 Update paramiko version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -60,7 +60,7 @@ ntlm-auth==1.4.0
     # via requests-ntlm
 packaging==20.3
     # via pytest
-paramiko==2.7.1
+paramiko==2.7.2
     # via fabric
 path.py==11.5.2
     # via cloudify-system-tests (setup.py)


### PR DESCRIPTION
Because with an updated version of openssl a bug in paramiko becomes
breaking. This was fixed in the latest update.