### PR TITLE
RD-2583 Add CA key to cfy_cluster_manager config

### DIFF
--- a/cosmo_tester/test_suites/cluster/cfy_cluster_manager_test.py
+++ b/cosmo_tester/test_suites/cluster/cfy_cluster_manager_test.py
@@ -73,6 +73,7 @@ def test_three_nodes_cluster_using_provided_certificates(
     three_nodes_config_dict = _get_config_dict(3, test_config)
     _update_three_nodes_config_dict_vms(three_nodes_config_dict, nodes_list)
     three_nodes_config_dict['ca_cert_path'] = join(REMOTE_CERTS_PATH, 'ca.pem')
+    three_nodes_config_dict['ca_key_path'] = join(REMOTE_CERTS_PATH, 'ca.key')
     for i, node in enumerate(nodes_list, start=1):
         three_nodes_config_dict['existing_vms']['node-{0}'.format(i)].update({
             'cert_path': join(REMOTE_CERTS_PATH, 'node-{0}.crt'.format(i)),
@@ -347,3 +348,4 @@ def _create_certificates(local_certs_path, nodes_list, pass_certs=False):
             node.put_remote_file(remote_cert, node_cert)
             node.put_remote_file(remote_key, node_key)
             node.put_remote_file(join(REMOTE_CERTS_PATH, 'ca.pem'), ca_cert)
+            node.put_remote_file(join(REMOTE_CERTS_PATH, 'ca.key'), ca_key)


### PR DESCRIPTION
This PR modifies the `test_three_nodes_cluster_using_provided_certificates` test logic to cope with the changes introduced here https://github.com/cloudify-cosmo/cloudify-cluster-manager/pull/89. 

Basically, adding the CA key in the use case of provided certificates.