### PR TITLE
Don't abort test if forgetting ssh key fails

### DIFF
--- a/cosmo_tester/framework/test_hosts.py
+++ b/cosmo_tester/framework/test_hosts.py
@@ -118,7 +118,9 @@ class VM(object):
                 addr=self.ip_address,
             )
         else:
-            subprocess.check_call(['ssh-keygen', '-R', self.ip_address])
+            # Don't check this call- it might fail due to missing known_hosts
+            # file or similar, and we shouldn't fail the test because of that.
+            subprocess.call(['ssh-keygen', '-R', self.ip_address])
             script_content = (
                 'ssh -i {key} -o StrictHostKeyChecking=no {connstr} ${{*}}\n'
             ).format(


### PR DESCRIPTION
If it really failed then a message will be given when the user tries to
use the ssh script.
In the Jenkins environment it can fail (probably due to the absence of
the known_hosts file).