### PR TITLE
Do not set install_config on non-cloudify nodes

### DIFF
--- a/cosmo_tester/test_suites/cluster/conftest.py
+++ b/cosmo_tester/test_suites/cluster/conftest.py
@@ -286,6 +286,9 @@ def _get_hosts(instances, test_config, logger,
         )
         hosts_entries = '\n'.join(hosts_entries)
         for node in instances:
+            if not hasattr(node, 'install_config'):
+                # This is a load balancer or other non-cloudify node
+                continue
             node.install_config['manager']['private_ip'] = node.hostname
             node.run_command(
                "echo '{hosts}' | sudo tee -a /etc/hosts".format(
@@ -294,6 +297,9 @@ def _get_hosts(instances, test_config, logger,
             )
     else:
         for node in instances:
+            if not hasattr(node, 'install_config'):
+                # This is a load balancer or other non-cloudify node
+                continue
             node.install_config['manager'][
                 'private_ip'] = node.private_ip_address
 


### PR DESCRIPTION
When setting up cluster nodes, we sometimes have nodes that aren't cloudify nodes,
e.g. a load balancer. These nodes do not have an install_config.