### PR TITLE
Remove agents dir on teardown test

### DIFF
--- a/cosmo_tester/test_suites/bootstrap/teardown_test.py
+++ b/cosmo_tester/test_suites/bootstrap/teardown_test.py
@@ -37,6 +37,15 @@ def test_teardown(bootstrap_test_manager, ssh_key, logger, test_config):
     expected_diffs['os groups'] = {'cfyagent'}
 
     bootstrap_test_manager.teardown(kill_certs=False)
+
+    # The agents dir should be empty, so let's remove it.
+    bootstrap_test_manager.run_command(
+        'rmdir /opt/cloudify-agent-{}'.format(
+            test_config['testing_version'].replace('-ga', '')
+        ),
+        use_sudo=True,
+    )
+
     current_state = _get_system_state(bootstrap_test_manager)
     diffs = {}
 


### PR DESCRIPTION
The agent itself gets removed, leaving the dir empty, but then the dir isn't cleaned up.
As there could technically be multiple agents this is maybe not a bug on the agent side.
However, as we know there won't be multiple agents, we should be able to remove it in the
test, and fail if we can't.