### PR TITLE
RD-2723 Isolate teardown test (don't reuse VM)

### DIFF
--- a/cosmo_tester/conftest.py
+++ b/cosmo_tester/conftest.py
@@ -100,6 +100,16 @@ def image_based_manager(session_manager):
     session_manager.teardown()
 
 
+@pytest.fixture(scope='function')
+def function_scoped_manager(request, ssh_key, session_tmpdir, test_config,
+                            session_logger):
+    hosts = Hosts(ssh_key, session_tmpdir, test_config,
+                  session_logger, request, bootstrappable=True)
+    hosts.create()
+    yield hosts.instances[0]
+    hosts.destroy()
+
+
 @pytest.fixture(scope='session')
 def three_plus_one_session_vms(ssh_key, session_tmpdir, test_config,
                                session_logger, request):


### PR DESCRIPTION
Otherwise the previous test can leave some resources behind which means we
can't check that everything we expect to be created/deleted/remaining is.