### PR TITLE
RD-2425 IPv6 cluster test

### DIFF
--- a/cosmo_tester/resources/infrastructure_blueprints/aws/infrastructure-ipv6.yaml
+++ b/cosmo_tester/resources/infrastructure_blueprints/aws/infrastructure-ipv6.yaml
@@ -1,0 +1,173 @@
+tosca_definitions_version: cloudify_dsl_1_3
+
+imports:
+  - https://cloudify.co/spec/cloudify/5.1.0/types.yaml
+  - plugin:cloudify-aws-plugin
+
+inputs:
+  test_infrastructure_name: {}
+
+dsl_definitions:
+  client_config: &client_config
+    aws_access_key_id: { get_secret: aws_access_key_id }
+    aws_secret_access_key: { get_secret: aws_secret_access_key }
+    region_name: { get_secret: ec2_region_name }
+
+node_templates:
+  keypair:
+    type: cloudify.nodes.aws.ec2.Keypair
+    properties:
+      resource_config:
+        KeyName: { get_input: test_infrastructure_name }
+        PublicKeyMaterial: { get_secret: ssh_public_key }
+      store_in_runtime_properties: true
+      client_config: *client_config
+
+  test_subnet_1:
+    type: cloudify.nodes.aws.ec2.Subnet
+    properties:
+      resource_config:
+        CidrBlock: 192.168.42.0/24
+        AvailabilityZone: { concat: [ { get_secret: ec2_region_name }, 'b' ]}
+        kwargs:
+          Ipv6CidrBlock: { get_attribute: [ vpc, create_response, Ipv6CidrBlockAssociationSet, 0, Ipv6CidrBlock ] }
+      client_config: *client_config
+      Tags:
+        - Key: Name
+          Value: { concat: [ { get_input: test_infrastructure_name }, "-1" ] }
+        - Key: Owner
+          Value: { get_secret: owner_tag }
+    relationships:
+      - type: cloudify.relationships.depends_on
+        target: vpc
+      - type: cloudify.relationships.depends_on
+        target: internet_gateway_1
+    interfaces:
+      cloudify.interfaces.lifecycle:
+        configure:
+          implementation: aws.cloudify_aws.ec2.resources.subnet.create
+          inputs:
+            modify_subnet_attribute_args:
+              AssignIpv6AddressOnCreation:
+                Value: True
+
+  vpc:
+    type: cloudify.nodes.aws.ec2.Vpc
+    properties:
+      resource_config:
+        CidrBlock: 192.168.0.0/16
+        kwargs:
+          AmazonProvidedIpv6CidrBlock: true
+      Tags:
+        - Key: Name
+          Value: { get_input: test_infrastructure_name }
+        - Key: Owner
+          Value: { get_secret: owner_tag }
+      client_config: *client_config
+
+  internet_gateway_1:
+    type: cloudify.nodes.aws.ec2.InternetGateway
+    properties:
+      client_config: *client_config
+      Tags:
+        - Key: Name
+          Value: { concat: [ { get_input: test_infrastructure_name }, "-1" ] }
+        - Key: Owner
+          Value: { get_secret: owner_tag }
+    relationships:
+      - type: cloudify.relationships.connected_to
+        target: vpc
+
+  subnet_routetable_1:
+    type: cloudify.nodes.aws.ec2.RouteTable
+    properties:
+      client_config: *client_config
+      Tags:
+        - Key: Name
+          Value: { concat: [ { get_input: test_infrastructure_name }, "-1" ] }
+        - Key: Owner
+          Value: { get_secret: owner_tag }
+    relationships:
+    - type: cloudify.relationships.contained_in
+      target: vpc
+    - type: cloudify.relationships.connected_to
+      target: test_subnet_1
+
+  route_subnet_internet_gateway_1:
+    type: cloudify.nodes.aws.ec2.Route
+    properties:
+      resource_config:
+        kwargs:
+          DestinationCidrBlock: '0.0.0.0/0'
+      client_config: *client_config
+    relationships:
+      - type: cloudify.relationships.contained_in
+        target: subnet_routetable_1
+      - type: cloudify.relationships.connected_to
+        target: internet_gateway_1
+
+  security_group:
+    type: cloudify.nodes.aws.ec2.SecurityGroup
+    properties:
+      resource_config:
+        GroupName: { get_input: test_infrastructure_name }
+        Description: Security group for tests.
+        VpcId: { get_attribute: [ vpc, aws_resource_id] }
+      client_config: *client_config
+    relationships:
+      - type: cloudify.relationships.depends_on
+        target: vpc
+
+  security_group_rules:
+    type: cloudify.nodes.aws.ec2.SecurityGroupRuleIngress
+    properties:
+     client_config: *client_config
+     resource_config:
+      IpPermissions:
+      - IpProtocol: tcp
+        FromPort: 22
+        ToPort: 22
+        IpRanges:
+        - CidrIp: 0.0.0.0/0
+      - IpProtocol: tcp
+        FromPort: 80
+        ToPort: 80
+        IpRanges:
+        - CidrIp: 0.0.0.0/0
+      - IpProtocol: tcp
+        FromPort: 443
+        ToPort: 443
+        IpRanges:
+        - CidrIp: 0.0.0.0/0
+      - IpProtocol: tcp
+        FromPort: 3389
+        ToPort: 3389
+        IpRanges:
+        - CidrIp: 0.0.0.0/0
+      - IpProtocol: tcp
+        FromPort: 5985
+        ToPort: 5985
+        IpRanges:
+        - CidrIp: 0.0.0.0/0
+      - IpProtocol: tcp
+        FromPort: 1
+        ToPort: 65535
+        IpRanges:
+        - CidrIp: 10.0.0.0/8
+        - CidrIp: 192.168.0.0/16
+        - CidrIp: 172.16.0.0/12
+      - IpProtocol: icmpv6
+        FromPort: -1
+        ToPort: -1
+        Ipv6Ranges:
+          - CidrIpv6: 2a05:d018::/32
+            Description: ICMPv6 on a AWS-provided IPv6 address range
+      - IpProtocol: tcp
+        FromPort: 1
+        ToPort: 65535
+        Ipv6Ranges:
+          - CidrIpv6: 2a05:d018::/32
+            Description: TCP on a AWS-provided IPv6 address range
+    relationships:
+      - type: cloudify.relationships.contained_in
+        target: security_group

--- a/cosmo_tester/resources/infrastructure_blueprints/aws/vm-ipv6.yaml
+++ b/cosmo_tester/resources/infrastructure_blueprints/aws/vm-ipv6.yaml
@@ -1,0 +1,150 @@
+tosca_definitions_version: cloudify_dsl_1_3
+
+imports:
+  - https://cloudify.co/spec/cloudify/5.1.0/types.yaml
+  - plugin:cloudify-aws-plugin
+
+inputs:
+  test_infrastructure_name: {}
+  security_group_id: {}
+  subnet_id: {}
+  vpc_id: {}
+  name_filter:
+    default:
+      Name: name
+      Values:
+        - "*"
+  image_owner:
+    default: "*"
+  image_id:
+    default: "*"
+  flavor: {}
+  userdata:
+    default: ""
+  use_net:
+    default: "1"
+
+dsl_definitions:
+  client_config: &client_config
+    aws_access_key_id: { get_secret: aws_access_key_id }
+    aws_secret_access_key: { get_secret: aws_secret_access_key }
+    region_name: { get_secret: ec2_region_name }
+
+node_templates:
+  test_host:
+    type: cloudify.nodes.aws.ec2.Instances
+    properties:
+      agent_config:
+        install_method: none
+      use_ipv6_ip: True
+      resource_config:
+        ImageId: { get_attribute: [ image, aws_resource_id ] }
+        InstanceType: { get_input: flavor }
+        kwargs:
+          KeyName: { get_input: test_infrastructure_name }
+          UserData: { get_input: userdata }
+      client_config: *client_config
+      Tags:
+        - Key: Name
+          Value: { get_input: test_infrastructure_name }
+        - Key: Owner
+          Value: { get_secret: owner_tag }
+    relationships:
+      - type: cloudify.relationships.depends_on
+        target: nic
+      - type: cloudify.relationships.depends_on
+        target: ip
+      - type: cloudify.relationships.depends_on
+        target: image
+
+  nic:
+    type: cloudify.nodes.aws.ec2.Interface
+    properties:
+      client_config: *client_config
+      resource_config:
+        kwargs:
+          Groups:
+            - { get_attribute: [ security_group, aws_resource_id ] }
+      Tags:
+        - Key: Name
+          Value: { concat: [ { get_input: test_infrastructure_name }, "-", { get_input: use_net } ] }
+        - Key: Owner
+          Value: { get_secret: owner_tag }
+    relationships:
+      - type: cloudify.relationships.depends_on
+        target: subnet
+      - type: cloudify.relationships.depends_on
+        target: security_group
+
+  ip:
+    type: cloudify.nodes.aws.ec2.ElasticIP
+    properties:
+      client_config: *client_config
+      Tags:
+        - Key: Name
+          Value: { concat: [ { get_input: test_infrastructure_name }, "-", { get_input: use_net } ] }
+        - Key: Owner
+          Value: { get_secret: owner_tag }
+    relationships:
+      - type: cloudify.relationships.depends_on
+        target: nic
+
+  subnet:
+    type: cloudify.nodes.aws.ec2.Subnet
+    properties:
+      use_external_resource: true
+      resource_id: { get_input: subnet_id }
+      client_config: *client_config
+      resource_config:
+        CidrBlock: 192.168.42.0/24
+        AvailabilityZone: { concat: [ { get_secret: ec2_region_name }, 'b' ]}
+        # IPv4 address is necessary for Elastic IP to work.
+        # Elastic IP is used in system-tests to communicate with a VM.
+      Tags:
+        - Key: Name
+          Value: { concat: [ { get_input: test_infrastructure_name }, "-", { get_input: use_net } ] }
+        - Key: Owner
+          Value: { get_secret: owner_tag }
+
+  security_group:
+    type: cloudify.nodes.aws.ec2.SecurityGroup
+    properties:
+      use_external_resource: true
+      resource_id: { get_input: security_group_id }
+      client_config: *client_config
+      resource_config:
+        GroupName: { get_input: test_infrastructure_name }
+        Description: Security group for tests.
+        VpcId: { get_attribute: [ vpc, aws_resource_id] }
+
+  vpc:
+    type: cloudify.nodes.aws.ec2.Vpc
+    properties:
+      use_external_resource: true
+      resource_id: { get_input: vpc_id }
+      resource_config:
+        CidrBlock: 192.168.0.0/16
+      Tags:
+        - Key: Name
+          Value: { get_input: test_infrastructure_name }
+        - Key: Owner
+          Value: { get_secret: owner_tag }
+      client_config: *client_config
+
+  image:
+    type: cloudify.nodes.aws.ec2.Image
+    properties:
+      resource_config:
+        kwargs:
+          Filters:
+            - { get_input: name_filter }
+            - Name: state
+              Values:
+                - available
+            - Name: owner-id
+              Values:
+                - { get_input: image_owner }
+            - Name: image-id
+              Values:
+                - { get_input: image_id }
+      client_config: *client_config

--- a/cosmo_tester/test_suites/cluster/compact_cluster_test.py
+++ b/cosmo_tester/test_suites/cluster/compact_cluster_test.py
@@ -66,6 +66,25 @@ def test_three_nodes_cluster_teardown(three_nodes_cluster, ssh_key,
     _assert_cluster_status(node1.client)
 
 
+@pytest.mark.three_vms_ipv6
+def test_three_nodes_cluster_ipv6(three_nodes_ipv6_cluster, logger,
+                                  ssh_key, test_config):
+    node1, node2, node3 = three_nodes_ipv6_cluster
+    _assert_cluster_status(node1.client)
+
+    logger.info('Installing example deployment on cluster')
+    example = get_example_deployment(node1, ssh_key, logger,
+                                     'ipv6_cluster_agent', test_config)
+    example.inputs['server_ip'] = node1.private_ip_address
+    example.upload_and_verify_install()
+    example.uninstall()
+
+    _verify_status_when_syncthing_inactive(node1, node2, logger)
+    _verify_status_when_postgres_inactive(node1, node2, logger, node3.client)
+    _verify_status_when_rabbit_inactive(node1, node2, node3, logger,
+                                        node1.client)
+
+
 def _get_new_credentials():
     monitoring_creds = {
         'username': _random_credential_generator(),

--- a/cosmo_tester/test_suites/cluster/conftest.py
+++ b/cosmo_tester/test_suites/cluster/conftest.py
@@ -34,6 +34,19 @@ def three_session_vms(request, ssh_key, session_tmpdir, test_config,
 
 
 @pytest.fixture(scope='session')
+def three_ipv6_session_vms(request, ssh_key, session_tmpdir, test_config,
+                           session_logger):
+    hosts = Hosts(ssh_key, session_tmpdir, test_config,
+                  session_logger, request, bootstrappable=True,
+                  number_of_instances=3, ipv6_net=True)
+    try:
+        hosts.create()
+        yield hosts.instances
+    finally:
+        hosts.destroy()
+
+
+@pytest.fixture(scope='session')
 def four_session_vms(request, ssh_key, session_tmpdir, test_config,
                      session_logger):
     hosts = Hosts(ssh_key, session_tmpdir, test_config,
@@ -190,12 +203,32 @@ def three_nodes_cluster(three_session_vms, test_config, logger):
 
 
 @pytest.fixture(scope='function')
+def three_nodes_ipv6_cluster(three_ipv6_session_vms, test_config, logger):
+    for vm in three_ipv6_session_vms:
+        _ensure_installer_installed(vm)
+    yield _get_hosts(three_ipv6_session_vms, test_config, logger,
+                     pre_cluster_rabbit=True, three_nodes_cluster=True)
+    for vm in three_ipv6_session_vms:
+        vm.teardown()
+
+
+@pytest.fixture(scope='function')
 def three_vms(three_session_vms, test_config, logger):
     for vm in three_nodes_cluster:
         _ensure_installer_not_installed(vm)
     yield _get_hosts(three_session_vms, test_config, logger,
                      three_nodes_cluster=True, bootstrap=False)
     for vm in three_session_vms:
+        vm.teardown()
+
+
+@pytest.fixture(scope='function')
+def three_vms_ipv6(three_ipv6_session_vms, test_config, logger):
+    for vm in three_nodes_ipv6_cluster:
+        _ensure_installer_not_installed(vm)
+    yield _get_hosts(three_ipv6_session_vms, test_config, logger,
+                     three_nodes_cluster=True, bootstrap=False)
+    for vm in three_ipv6_session_vms:
         vm.teardown()
 
 


### PR DESCRIPTION
* Add {infrastructure,vm}-ipv6-net blueprints, these are use to test
  IPv6-enabled cluster

* Add test_three_nodes_cluster_ipv6_status and ipv6 fixtures

* Use ipv6_address as a private_ip_address in ipv6_net test.
  The `private_ip_address` is actually used as both `private_ip` and
  `public_ip` in `/etc/cloudify/config.yaml`.

* Disable IPv4 in case of IPv6 test(s)

* Add a comment about IPv4 in the vm-ipv6-net blueprint

* Make a blueprint suffix generation more readable and easier to extend

* Add a comment on disabling IPv4 in a cluster

* Rename blueprints: `ipv6` without `-net` suffix

* Verify agent too