### PR TITLE
Include sanity for teardown test

### DIFF
--- a/cosmo_tester/test_suites/bootstrap/teardown_test.py
+++ b/cosmo_tester/test_suites/bootstrap/teardown_test.py
@@ -7,7 +7,7 @@ pre_bootstrap_state = None
 def test_teardown(function_scoped_manager, ssh_key, logger, test_config):
     function_scoped_manager.wait_for_ssh()
     check_pre_bootstrap_state(function_scoped_manager)
-    function_scoped_manager.bootstrap(blocking=True)
+    function_scoped_manager.bootstrap(blocking=True, include_sanity=True)
 
     expected_diffs = {}
 


### PR DESCRIPTION
It's expected to be used in general, so we should make sure it doesn't leak resources.