### PR TITLE
Remove cancel+resume testing for service composition

### DIFF
--- a/cosmo_tester/test_suites/service_composition/__init__.py
+++ b/cosmo_tester/test_suites/service_composition/__init__.py
@@ -51,31 +51,6 @@ def _check_custom_execute_operation(app, logger):
         workflow_id='execute_operation')[0].status == 'terminated'
 
 
-def _verify_custom_execution_cancel_and_resume(app, logger):
-    # plant runtime property which conditions the execution to fail
-    instances = app.manager.client.node_instances.list(deployment_id='app',
-                                                       node_id='app')
-    app.manager.client.node_instances.update(
-        instances[0].id,
-        runtime_properties={'fail_commit': True},
-        version=instances[0].version + 1
-    )
-    rollout = app.manager.client.executions.start('app', 'rollout')
-
-    logger.info('Testing execution cancel.')
-    app.manager.client.executions.cancel(rollout.id)
-    util.wait_for_execution_status(app, rollout.id, 'cancelled')
-
-    app.manager.client.node_instances.update(
-        instances[0].id,
-        runtime_properties={'fail_commit': False},
-        version=instances[0].version + 1
-    )
-    logger.info('Testing execution resume.')
-    app.manager.client.executions.resume(rollout.id)
-    util.wait_for_execution_status(app, rollout.id, 'terminated')
-
-
 def _verify_deployments_and_nodes(app, number_of_deployments):
     # verify all deployments exist
     assert len(app.manager.client.deployments.list()) == number_of_deployments

--- a/cosmo_tester/test_suites/service_composition/component_test.py
+++ b/cosmo_tester/test_suites/service_composition/component_test.py
@@ -1,6 +1,5 @@
 from cosmo_tester.framework import util
 from . import (_infra, _app, _check_custom_execute_operation,
-               _verify_custom_execution_cancel_and_resume,
                _verify_deployments_and_nodes)
 
 
@@ -19,7 +18,6 @@ def test_component(image_based_manager, ssh_key, logger, test_config):
     with util.set_client_tenant(app.manager.client, tenant):
         _verify_deployments_and_nodes(app, 2)
         _check_custom_execute_operation(app, logger)
-        _verify_custom_execution_cancel_and_resume(app, logger)
 
         # verify that uninstall of app removes the infra + its deployment
         logger.info('Testing component uninstall.')

--- a/cosmo_tester/test_suites/service_composition/shared_resource_test.py
+++ b/cosmo_tester/test_suites/service_composition/shared_resource_test.py
@@ -3,7 +3,6 @@ import pytest
 from cosmo_tester.framework import util
 from cosmo_tester.framework.test_hosts import Hosts
 from . import (_infra, _app, _check_custom_execute_operation,
-               _verify_custom_execution_cancel_and_resume,
                _verify_deployments_and_nodes)
 from cloudify_rest_client.exceptions import CloudifyClientError
 
@@ -23,7 +22,6 @@ def test_shared_resource(image_based_manager, ssh_key, logger, test_config):
     with util.set_client_tenant(app.manager.client, tenant):
         _verify_deployments_and_nodes(app, 2)
         _check_custom_execute_operation(app, logger)
-        _verify_custom_execution_cancel_and_resume(app, logger)
 
 
 @pytest.fixture(scope='function')


### PR DESCRIPTION
Custom workflows are not resumable anymore since the fix here: https://github.com/cloudify-cosmo/cloudify-common/pull/886
And workflow resumption is tested thoroughly in integration tests, so removed from here