### PR TITLE
Make cleanup script cope with untagged resources

### DIFF
--- a/aws_cleanup
+++ b/aws_cleanup
@@ -62,12 +62,25 @@ def tags_to_dict(entity, tag_key):
     return {item['Key']: item['Value'] for item in entity[tag_key]}
 
 
-def _append_entities_to_previous_tests(entities, entity_type, previous_tests):
+def get_test_name(entity, tag_key):
+    return tags_to_dict(entity, tag_key)['Name']
+
+
+def _append_entities_to_previous_tests(entities, entity_type, previous_tests,
+                                       test_name):
+    id_key = ENTITY_TYPES[entity_type]['id_key']
+    for entity in entities:
+        if test_name not in previous_tests:
+            previous_tests[test_name] = {e: [] for e in ENTITY_TYPES}
+        previous_tests[test_name][entity_type].append(entity[id_key])
+
+
+def group_non_vpc_entities_by_previous_tests(entities, entity_type,
+                                             previous_tests):
     tag_key = ENTITY_TYPES[entity_type]['tag_key']
     id_key = ENTITY_TYPES[entity_type]['id_key']
     for entity in entities:
-        tags = tags_to_dict(entity, tag_key)
-        test_name = tags['Name']
+        test_name = get_test_name(entity, tag_key)
         if entity_type in ['interfaces', 'subnets', 'route tables',
                            'internet gateways', 'elastic ips']:
             test_name = test_name.rsplit('-', 1)[0]
@@ -76,68 +89,70 @@ def _append_entities_to_previous_tests(entities, entity_type, previous_tests):
         previous_tests[test_name][entity_type].append(entity[id_key])
 
 
-def group_by_previous_tests(instances, interfaces, vpcs, subnets, elastic_ips,
-                            route_tables, internet_gateways, security_groups):
-    previous_tests = {}
+def group_by_previous_tests(instances, interfaces, subnets,
+                            route_tables, internet_gateways,
+                            security_groups,
+                            vpc, previous_tests):
+    test_name = get_test_name(vpc, ENTITY_TYPES['vpcs']['tag_key'])
 
+    _append_entities_to_previous_tests(
+        entities=[vpc],
+        entity_type='vpcs',
+        previous_tests=previous_tests,
+        test_name=test_name,
+    )
     _append_entities_to_previous_tests(
         entities=instances,
         entity_type='instances',
         previous_tests=previous_tests,
+        test_name=test_name,
     )
     _append_entities_to_previous_tests(
         entities=interfaces,
         entity_type='interfaces',
         previous_tests=previous_tests,
-    )
-    _append_entities_to_previous_tests(
-        entities=vpcs,
-        entity_type='vpcs',
-        previous_tests=previous_tests,
+        test_name=test_name,
     )
     _append_entities_to_previous_tests(
         entities=subnets,
         entity_type='subnets',
         previous_tests=previous_tests,
-    )
-    _append_entities_to_previous_tests(
-        entities=elastic_ips,
-        entity_type='elastic ips',
-        previous_tests=previous_tests,
+        test_name=test_name,
     )
     _append_entities_to_previous_tests(
         entities=route_tables,
         entity_type='route tables',
         previous_tests=previous_tests,
+        test_name=test_name,
     )
     _append_entities_to_previous_tests(
         entities=internet_gateways,
         entity_type='internet gateways',
         previous_tests=previous_tests,
+        test_name=test_name,
     )
     _append_entities_to_previous_tests(
         entities=security_groups,
         entity_type='security groups',
         previous_tests=previous_tests,
+        test_name=test_name,
     )
 
-    return previous_tests
 
-
-def get_instances(client, owner):
+def get_instances(client, vpc):
     reservations = client.describe_instances(
         Filters=[
-            {'Name': 'tag:Owner', 'Values': [owner]},
+            {'Name': 'vpc-id', 'Values': [vpc]},
             {'Name': 'instance-state-name', 'Values': NOT_TERMINATED},
         ],
     )['Reservations']
     return [res['Instances'][0] for res in reservations]
 
 
-def get_interfaces(client, owner):
+def get_interfaces(client, vpc):
     return client.describe_network_interfaces(
         Filters=[
-            {'Name': 'tag:Owner', 'Values': [owner]}
+            {'Name': 'vpc-id', 'Values': [vpc]}
         ],
     )['NetworkInterfaces']
 
@@ -150,10 +165,10 @@ def get_vpcs(client, owner):
     )['Vpcs']
 
 
-def get_subnets(client, owner):
+def get_subnets(client, vpc):
     return client.describe_subnets(
         Filters=[
-            {'Name': 'tag:Owner', 'Values': [owner]}
+            {'Name': 'vpc-id', 'Values': [vpc]}
         ],
     )['Subnets']
 
@@ -166,28 +181,39 @@ def get_elastic_ips(client, owner):
     )['Addresses']
 
 
-def get_route_tables(client, owner):
-    return client.describe_route_tables(
+def get_route_tables(client, vpc):
+    route_tables = client.describe_route_tables(
         Filters=[
-            {'Name': 'tag:Owner', 'Values': [owner]}
+            {'Name': 'vpc-id', 'Values': [vpc]}
         ],
     )['RouteTables']
+    return [
+        route_table for route_table in route_tables
+        # Don't return Main ones, we can't delete them
+        if not any(assoc.get('Main')
+                   for assoc in route_table.get('Associations', []))
+    ]
 
 
-def get_internet_gateways(client, owner):
+def get_internet_gateways(client, vpc):
     return client.describe_internet_gateways(
         Filters=[
-            {'Name': 'tag:Owner', 'Values': [owner]}
+            {'Name': 'attachment.vpc-id', 'Values': [vpc]}
         ],
     )['InternetGateways']
 
 
-def get_security_groups(client, owner):
-    return client.describe_security_groups(
+def get_security_groups(client, vpc):
+    security_groups = client.describe_security_groups(
         Filters=[
-            {'Name': 'tag:Owner', 'Values': [owner]}
+            {'Name': 'vpc-id', 'Values': [vpc]}
         ],
     )['SecurityGroups']
+    return [
+        sec_group for sec_group in security_groups
+        # Don't return default ones, we can't delete them
+        if sec_group.get('GroupName') != 'default'
+    ]
 
 
 def estimate_age(test_name):
@@ -196,11 +222,11 @@ def estimate_age(test_name):
     now = datetime.now()
 
     difference = now - test_time
-    hours = difference.seconds // 60 // 60
+    hours = int(difference.total_seconds()) // 60 // 60
     if hours == 0:
-        minutes = difference.seconds // 60
+        minutes = int(difference.total_seconds()) // 60
     else:
-        minutes = difference.seconds // 60 % (60 * hours)
+        minutes = int(difference.total_seconds()) // 60 % (60 * hours)
     return hours, minutes
 
 
@@ -404,20 +430,27 @@ def main(older_than, newer_than, owner, delete):
     if not owner:
         owner = conf['aws']['owner_tag']
 
-    instances = get_instances(client, owner)
-    interfaces = get_interfaces(client, owner)
-    vpcs = get_vpcs(client, owner)
-    subnets = get_subnets(client, owner)
-    elastic_ips = get_elastic_ips(client, owner)
-    route_tables = get_route_tables(client, owner)
-    internet_gateways = get_internet_gateways(client, owner)
-    security_groups = get_security_groups(client, owner)
+    resources_by_test = {}
 
-    resources_by_test = group_by_previous_tests(instances, interfaces, vpcs,
-                                                subnets, elastic_ips,
-                                                route_tables,
-                                                internet_gateways,
-                                                security_groups)
+    vpcs = get_vpcs(client, owner)
+    for vpc in vpcs:
+        vpc_id = vpc['VpcId']
+        instances = get_instances(client, vpc_id)
+        interfaces = get_interfaces(client, vpc_id)
+        subnets = get_subnets(client, vpc_id)
+        route_tables = get_route_tables(client, vpc_id)
+        security_groups = get_security_groups(client, vpc_id)
+        internet_gateways = get_internet_gateways(client, vpc_id)
+
+        group_by_previous_tests(instances, interfaces,
+                                subnets, route_tables,
+                                internet_gateways,
+                                security_groups,
+                                vpc, resources_by_test)
+
+    elastic_ips = get_elastic_ips(client, owner)
+    group_non_vpc_entities_by_previous_tests(elastic_ips, 'elastic ips',
+                                             resources_by_test)
 
     filter_test_groups(resources_by_test, older_than, newer_than)
 


### PR DESCRIPTION
The VPC MUST be tagged, but we will now delete all child resources
of any correctly tagged VPC when we try to.

The only resource we can now leak is EIPs because they don't belong
to a VPC, so if they're not tagged... sadness is a thing.

Estimate age will also return hours above 24 now.