### PR TITLE
Roll back BP update for dep update

### DIFF
--- a/cosmo_tester/resources/blueprints/compute/example_2_files.yaml
+++ b/cosmo_tester/resources/blueprints/compute/example_2_files.yaml
@@ -15,37 +15,15 @@ inputs:
     default: centos
   path: {}
   content: {}
-  os_family:
-    default: linux
-  agent_port:
-    default: 22
-  agent_password:
-    default: ""
-  wait:
-    description: How long wait node should delay, in seconds.
-    default: 0
-  service_user:
-    default: ""
-  service_password:
-    default: ""
-  network:
-    default: default
 
 node_templates:
   vm:
     type: cloudify.nodes.Compute
     properties:
       ip: { get_input: server_ip }
-      os_family: { get_input: os_family }
       agent_config:
         user: { get_input: agent_user }
         key: { get_secret: agent_key }
-        password: { get_input: agent_password }
-        port: { get_input: agent_port }
-        network: { get_input: network }
-        process_management:
-          service_user: { get_input: service_user }
-          service_password: { get_input: service_password }
 
   file:
     type: cloudify.test.nodes.File


### PR DESCRIPTION
The old blueprint should actually have worked, so we'll leave this as it was.