### PR TITLE
Don't run session logic (backup/restore) on 1 test

### DIFF
--- a/cosmo_tester/conftest.py
+++ b/cosmo_tester/conftest.py
@@ -90,18 +90,20 @@ def session_manager(request, ssh_key, session_tmpdir, test_config,
     hosts = Hosts(ssh_key, session_tmpdir, test_config,
                   session_logger, request, bootstrappable=True)
     hosts.create()
-    hosts.rsync_backup()
+    if len(request.session.items) > 1:
+        hosts.rsync_backup()
     yield hosts.instances[0]
     hosts.destroy()
 
 
 @pytest.fixture(scope='function')
-def image_based_manager(session_manager, session_logger):
+def image_based_manager(session_manager, session_logger, request):
     reboot_if_required([session_manager])
     session_manager.bootstrap()
     yield session_manager
     session_manager.teardown()
-    rsync_restore([session_manager], session_logger)
+    if len(request.session.items) > 1:
+        rsync_restore([session_manager], session_logger)
 
 
 @pytest.fixture(scope='function')
@@ -123,21 +125,24 @@ def three_plus_one_session_vms(ssh_key, session_tmpdir, test_config,
     hosts.instances[-1] = VM('centos_7', test_config)
 
     hosts.create()
-    hosts.rsync_backup()
+    if len(request.session.items) > 1:
+        hosts.rsync_backup()
     yield hosts.instances
     hosts.destroy()
 
 
 @pytest.fixture(scope='function')
 def three_node_cluster_with_extra_node(test_config, session_logger,
-                                       three_plus_one_session_vms):
+                                       three_plus_one_session_vms,
+                                       request):
     reboot_if_required(three_plus_one_session_vms)
     yield _get_hosts(three_plus_one_session_vms,
                      test_config, session_logger,
                      pre_cluster_rabbit=True,
                      three_nodes_cluster=True,
                      extra_node=True)
-    rsync_restore(three_plus_one_session_vms, session_logger)
+    if len(request.session.items) > 1:
+        rsync_restore(three_plus_one_session_vms, session_logger)
 
 
 @pytest.fixture(scope='session')
@@ -148,7 +153,8 @@ def three_plus_manager_session_vms(ssh_key, session_tmpdir, test_config,
                   number_of_instances=4)
 
     hosts.create()
-    hosts.rsync_backup()
+    if len(request.session.items) > 1:
+        hosts.rsync_backup()
     yield hosts.instances
     hosts.destroy()
 
@@ -157,11 +163,13 @@ def three_plus_manager_session_vms(ssh_key, session_tmpdir, test_config,
                          indirect=['three_plus_one_session_vms'])
 @pytest.fixture(scope='function')
 def three_node_cluster_with_extra_manager(test_config, session_logger,
-                                          three_plus_manager_session_vms):
+                                          three_plus_manager_session_vms,
+                                          request):
     reboot_if_required(three_plus_manager_session_vms)
     yield _get_hosts(three_plus_manager_session_vms,
                      test_config, session_logger,
                      pre_cluster_rabbit=True,
                      three_nodes_cluster=True,
                      extra_node=True)
-    rsync_restore(three_plus_manager_session_vms, session_logger)
+    if len(request.session.items) > 1:
+        rsync_restore(three_plus_manager_session_vms, session_logger)

--- a/cosmo_tester/test_suites/cluster/conftest.py
+++ b/cosmo_tester/test_suites/cluster/conftest.py
@@ -29,7 +29,8 @@ def three_session_vms(request, ssh_key, session_tmpdir, test_config,
                   number_of_instances=3)
     try:
         hosts.create()
-        hosts.rsync_backup()
+        if len(request.session.items) > 1:
+            hosts.rsync_backup()
         yield hosts.instances
     finally:
         hosts.destroy()
@@ -43,7 +44,8 @@ def three_ipv6_session_vms(request, ssh_key, session_tmpdir, test_config,
                   number_of_instances=3, ipv6_net=True)
     try:
         hosts.create()
-        hosts.rsync_backup()
+        if len(request.session.items) > 1:
+            hosts.rsync_backup()
         yield hosts.instances
     finally:
         hosts.destroy()
@@ -57,7 +59,8 @@ def four_session_vms(request, ssh_key, session_tmpdir, test_config,
                   number_of_instances=4)
     try:
         hosts.create()
-        hosts.rsync_backup()
+        if len(request.session.items) > 1:
+            hosts.rsync_backup()
         yield hosts.instances
     finally:
         hosts.destroy()
@@ -71,7 +74,8 @@ def six_session_vms(request, ssh_key, session_tmpdir, test_config,
                   number_of_instances=6)
     try:
         hosts.create()
-        hosts.rsync_backup()
+        if len(request.session.items) > 1:
+            hosts.rsync_backup()
         yield hosts.instances
     finally:
         hosts.destroy()
@@ -85,92 +89,101 @@ def nine_session_vms(request, ssh_key, session_tmpdir, test_config,
                   number_of_instances=9)
     try:
         hosts.create()
-        hosts.rsync_backup()
+        if len(request.session.items) > 1:
+            hosts.rsync_backup()
         yield hosts.instances
     finally:
         hosts.destroy()
 
 
 @pytest.fixture(scope='function')
-def brokers(three_session_vms, test_config, logger):
+def brokers(three_session_vms, test_config, logger, request):
     reboot_if_required(three_session_vms)
     for vm in three_session_vms:
         _ensure_installer_installed(vm)
     yield _get_hosts(three_session_vms, test_config, logger,
                      broker_count=3)
-    rsync_restore(three_session_vms, logger)
+    if len(request.session.items) > 1:
+        rsync_restore(three_session_vms, logger)
 
 
 @pytest.fixture(scope='function')
-def broker(session_manager, test_config, logger):
+def broker(session_manager, test_config, logger, request):
     reboot_if_required([session_manager])
     _brokers = _get_hosts([session_manager], test_config, logger,
                           broker_count=1)
     yield _brokers[0]
-    rsync_restore([session_manager], logger)
+    if len(request.session.items) > 1:
+        rsync_restore([session_manager], logger)
 
 
 @pytest.fixture(scope='function')
-def dbs(three_session_vms, test_config, logger):
+def dbs(three_session_vms, test_config, logger, request):
     reboot_if_required(three_session_vms)
     for vm in three_session_vms:
         _ensure_installer_installed(vm)
     yield _get_hosts(three_session_vms, test_config, logger,
                      db_count=3)
-    rsync_restore(three_session_vms, logger)
+    if len(request.session.items) > 1:
+        rsync_restore(three_session_vms, logger)
 
 
 @pytest.fixture(scope='function')
-def brokers_and_manager(three_session_vms, test_config, logger):
+def brokers_and_manager(three_session_vms, test_config, logger, request):
     reboot_if_required(three_session_vms)
     for vm in three_session_vms:
         _ensure_installer_installed(vm)
     yield _get_hosts(three_session_vms, test_config, logger,
                      broker_count=2, manager_count=1)
-    rsync_restore(three_session_vms, logger)
+    if len(request.session.items) > 1:
+        rsync_restore(three_session_vms, logger)
 
 
 @pytest.fixture(scope='function')
-def brokers3_and_manager(four_session_vms, test_config, logger):
+def brokers3_and_manager(four_session_vms, test_config, logger, request):
     reboot_if_required(four_session_vms)
     yield _get_hosts(four_session_vms, test_config, logger,
                      broker_count=3, manager_count=1)
-    rsync_restore(four_session_vms, logger)
+    if len(request.session.items) > 1:
+        rsync_restore(four_session_vms, logger)
 
 
 @pytest.fixture(scope='function')
-def full_cluster_ips(nine_session_vms, test_config, logger):
+def full_cluster_ips(nine_session_vms, test_config, logger, request):
     reboot_if_required(nine_session_vms)
     for vm in nine_session_vms:
         _ensure_installer_installed(vm)
     yield _get_hosts(nine_session_vms, test_config, logger,
                      broker_count=3, db_count=3, manager_count=3,
                      pre_cluster_rabbit=True)
-    rsync_restore(nine_session_vms, logger)
+    if len(request.session.items) > 1:
+        rsync_restore(nine_session_vms, logger)
 
 
 @pytest.fixture(scope='function')
-def full_cluster_names(nine_session_vms, test_config, logger):
+def full_cluster_names(nine_session_vms, test_config, logger, request):
     reboot_if_required(nine_session_vms)
     for vm in nine_session_vms:
         _ensure_installer_installed(vm)
     yield _get_hosts(nine_session_vms, test_config, logger,
                      broker_count=3, db_count=3, manager_count=3,
                      pre_cluster_rabbit=True, use_hostnames=True)
-    rsync_restore(nine_session_vms, logger)
+    if len(request.session.items) > 1:
+        rsync_restore(nine_session_vms, logger)
 
 
 @pytest.fixture(scope='function')
-def cluster_with_lb(six_session_vms, test_config, logger):
+def cluster_with_lb(six_session_vms, test_config, logger, request):
     reboot_if_required(six_session_vms)
     yield _get_hosts(six_session_vms, test_config, logger,
                      broker_count=1, db_count=1, manager_count=3,
                      use_load_balancer=True, pre_cluster_rabbit=True)
-    rsync_restore(six_session_vms, logger)
+    if len(request.session.items) > 1:
+        rsync_restore(six_session_vms, logger)
 
 
 @pytest.fixture(scope='function')
-def cluster_missing_one_db(nine_session_vms, test_config, logger):
+def cluster_missing_one_db(nine_session_vms, test_config, logger, request):
     reboot_if_required(nine_session_vms)
     for vm in nine_session_vms:
         _ensure_installer_installed(vm)
@@ -178,76 +191,85 @@ def cluster_missing_one_db(nine_session_vms, test_config, logger):
                      broker_count=3, db_count=3, manager_count=3,
                      skip_bootstrap_list=['db3'],
                      pre_cluster_rabbit=True)
-    rsync_restore(nine_session_vms, logger)
+    if len(request.session.items) > 1:
+        rsync_restore(nine_session_vms, logger)
 
 
 @pytest.fixture(scope='function')
-def cluster_with_single_db(six_session_vms, test_config, logger):
+def cluster_with_single_db(six_session_vms, test_config, logger, request):
     reboot_if_required(six_session_vms)
     yield _get_hosts(six_session_vms, test_config, logger,
                      broker_count=3, db_count=1, manager_count=2,
                      pre_cluster_rabbit=True)
-    rsync_restore(six_session_vms, logger)
+    if len(request.session.items) > 1:
+        rsync_restore(six_session_vms, logger)
 
 
 @pytest.fixture(scope='function')
-def minimal_cluster(four_session_vms, test_config, logger):
+def minimal_cluster(four_session_vms, test_config, logger, request):
     reboot_if_required(four_session_vms)
     yield _get_hosts(four_session_vms, test_config, logger,
                      broker_count=1, db_count=1, manager_count=2,
                      pre_cluster_rabbit=True)
-    rsync_restore(four_session_vms, logger)
+    if len(request.session.items) > 1:
+        rsync_restore(four_session_vms, logger)
 
 
 @pytest.fixture(scope='function')
-def three_nodes_cluster(three_session_vms, test_config, logger):
+def three_nodes_cluster(three_session_vms, test_config, logger, request):
     reboot_if_required(three_session_vms)
     for vm in three_session_vms:
         _ensure_installer_installed(vm)
     yield _get_hosts(three_session_vms, test_config, logger,
                      pre_cluster_rabbit=True, three_nodes_cluster=True)
-    rsync_restore(three_session_vms, logger)
+    if len(request.session.items) > 1:
+        rsync_restore(three_session_vms, logger)
 
 
 @pytest.fixture(scope='function')
-def three_nodes_ipv6_cluster(three_ipv6_session_vms, test_config, logger):
+def three_nodes_ipv6_cluster(three_ipv6_session_vms, test_config, logger,
+                             request):
     reboot_if_required(three_ipv6_session_vms)
     for vm in three_ipv6_session_vms:
         _ensure_installer_installed(vm)
     yield _get_hosts(three_ipv6_session_vms, test_config, logger,
                      pre_cluster_rabbit=True, three_nodes_cluster=True)
-    rsync_restore(three_ipv6_session_vms, logger)
+    if len(request.session.items) > 1:
+        rsync_restore(three_ipv6_session_vms, logger)
 
 
 @pytest.fixture(scope='function')
-def three_vms(three_session_vms, test_config, logger):
+def three_vms(three_session_vms, test_config, logger, request):
     reboot_if_required(three_session_vms)
     for vm in three_session_vms:
         _ensure_installer_not_installed(vm)
     yield _get_hosts(three_session_vms, test_config, logger,
                      three_nodes_cluster=True, bootstrap=False)
-    rsync_restore(three_session_vms, logger)
+    if len(request.session.items) > 1:
+        rsync_restore(three_session_vms, logger)
 
 
 @pytest.fixture(scope='function')
-def three_vms_ipv6(three_ipv6_session_vms, test_config, logger):
+def three_vms_ipv6(three_ipv6_session_vms, test_config, logger, request):
     reboot_if_required(three_ipv6_session_vms)
     for vm in three_nodes_ipv6_cluster:
         _ensure_installer_not_installed(vm)
     yield _get_hosts(three_ipv6_session_vms, test_config, logger,
                      three_nodes_cluster=True, bootstrap=False)
-    rsync_restore(three_ipv6_session_vms, logger)
+    if len(request.session.items) > 1:
+        rsync_restore(three_ipv6_session_vms, logger)
 
 
 @pytest.fixture(scope='function')
-def nine_vms(nine_session_vms, test_config, logger):
+def nine_vms(nine_session_vms, test_config, logger, request):
     reboot_if_required(nine_session_vms)
     for vm in nine_session_vms:
         _ensure_installer_not_installed(vm)
     yield _get_hosts(nine_session_vms, test_config, logger,
                      broker_count=3, db_count=3,
                      manager_count=3, bootstrap=False)
-    rsync_restore(nine_session_vms, logger)
+    if len(request.session.items) > 1:
+        rsync_restore(nine_session_vms, logger)
 
 
 def _ensure_installer_not_installed(vm):


### PR DESCRIPTION
This makes a single test much quicker to run locally.