### PR TITLE
Don't leak installed config list between tests

### DIFF
--- a/cosmo_tester/test_suites/cluster/broker_management_test.py
+++ b/cosmo_tester/test_suites/cluster/broker_management_test.py
@@ -75,7 +75,6 @@ def get_cluster_listing(cluster_brokers, down=()):
 
 
 def kill_node(broker):
-    broker.set_installed_configs()
     broker.stop_manager_services()
 
 

--- a/cosmo_tester/test_suites/cluster/cfy_cluster_manager_shared.py
+++ b/cosmo_tester/test_suites/cluster/cfy_cluster_manager_shared.py
@@ -73,9 +73,6 @@ def _install_cluster(node, all_nodes, config_dict, test_config, ssh_key,
             override='--override' if override else '')
     )
 
-    for n in all_nodes:
-        n.set_installed_configs()
-
     logger.info('Verifying the cluster status')
     _verify_cluster_status(node)
 
@@ -143,10 +140,9 @@ def _cluster_upgrade_test(test_config, base_version, nodes,
     if base_version.startswith('5.0') or base_version.startswith('5.1'):
         # These base versions use systemd for service management
         for node in nodes:
-            node.set_installed_configs()
             # Yes, using the private var is horrible, but we can hopefully
             # retire these versions soon and remove this hack...
-            for conf in node._installed_configs:
+            for conf in node.get_installed_configs():
                 node.run_command(
                     'echo -e \\\\nservice_management: systemd '
                     '| sudo tee -a {}'.format(conf)


### PR DESCRIPTION
We also check there is at least one main service before trying to run the stop,
because currently the installer doesn't clear up others (and those others should
not be there anyway, as they're components of the actual services we provide).