### PR TITLE
Don't allow dangerous versions of AWS plugin

### DIFF
--- a/cosmo_tester/config_schemas/platform_aws.yaml
+++ b/cosmo_tester/config_schemas/platform_aws.yaml
@@ -15,7 +15,7 @@ plugin_package_name:
   default: cloudify-aws-plugin
 plugin_version:
   description: The expected version of this plugin (can be a regular expression).
-  default: ^2\.\d+\.\d+$
+  default: ^2\.8\.\d+$
 linux_size:
   description: Size to use for linux on this platform.
   # This needs to be an instance that can accept 3 network interfaces

--- a/cosmo_tester/framework/test_hosts.py
+++ b/cosmo_tester/framework/test_hosts.py
@@ -1273,8 +1273,10 @@ class Hosts(object):
         else:
             raise RuntimeError(
                 'The manager must have a plugin called {}. '
-                'This should be uploaded with --visibility=global.'.format(
+                'This should be uploaded with --visibility=global,'
+                'and match version regex: {}'.format(
                     plugin_details['plugin_package_name'],
+                    plugin_details['plugin_version'],
                 )
             )
 


### PR DESCRIPTION
We know 2.8.0 works, we know 2.14.0 deletes important images.
Let's just pin to 2.8 for now as we're near release.