### PR TITLE
RD-4188 Add a test that uses http proxy

### DIFF
--- a/cosmo_tester/resources/blueprints/proxy/proxy_blueprint.yaml
+++ b/cosmo_tester/resources/blueprints/proxy/proxy_blueprint.yaml
@@ -1,0 +1,13 @@
+tosca_definitions_version: cloudify_dsl_1_3
+
+imports:
+  - cloudify/types/types.yaml
+
+node_templates:
+  node1:
+    type: cloudify.nodes.Root
+    interfaces:
+      run:
+        via_proxy:
+          executor: central_deployment_agent
+          implementation: scripts/download_via_proxy.py

--- a/cosmo_tester/resources/blueprints/proxy/scripts/download_via_proxy.py
+++ b/cosmo_tester/resources/blueprints/proxy/scripts/download_via_proxy.py
@@ -1,0 +1,13 @@
+from cloudify import ctx
+import requests
+
+error_message = ''
+try:
+    requests.get('https://example.com')
+except Exception as e:
+    error_message = str(e)
+if 'proxy' not in error_message:
+    ctx.abort_operation(
+        'Expected the error to be caused by proxy, but was: {0}'
+        .format(error_message)
+    )

--- a/cosmo_tester/test_suites/bootstrap/proxy_test.py
+++ b/cosmo_tester/test_suites/bootstrap/proxy_test.py
@@ -1,0 +1,35 @@
+from cosmo_tester.framework import util
+
+
+def test_proxy(bootstrap_test_manager, logger, tmpdir, test_config):
+    """Start a manager with proxy settings, and check that it uses the proxy.
+
+    The operation is going to attempt to reach out to the internet, and
+    it's going to assert that it fails with a proxy error, because there's
+    no proxy set up. We only need to check that cloudify correctly attempts
+    to use the proxy. We don't need to test the proxy itself.
+    """
+    manager = bootstrap_test_manager
+    proxy_env = {
+        'HTTP_PROXY': f'http://{manager.private_ip_address}',
+        'HTTPS_PROXY': f'https://{manager.private_ip_address}',
+        'NO_PROXY': f'{manager.private_ip_address},127.0.0.1,localhost',
+    }
+    manager.install_config.setdefault('stage', {}).update(
+        extra_env=proxy_env)
+    manager.install_config.setdefault('mgmtworker', {}).update(
+        extra_env=proxy_env)
+    manager.bootstrap(include_sanity=True)
+    manager.client.blueprints.upload(
+        util.get_resource_path(
+            'blueprints/proxy/proxy_blueprint.yaml'
+        ),
+        'proxy_blueprint'
+    )
+    manager.client.deployments.create('proxy_blueprint', 'proxy_deployment')
+    execution = manager.client.executions.create(
+        'proxy_deployment',
+        'execute_operation',
+        parameters={'operation': 'run.via_proxy'}
+    )
+    util.wait_for_execution(manager.client, execution, logger)


### PR DESCRIPTION
Set up http proxy in the manager, and check that we do use it.

Importantly, I have checked that it also uses the proxy for stage,
although we don't have a way to automatically assert it here.