### PR TITLE
Don't call snapshots with password

### DIFF
--- a/cosmo_tester/test_suites/agent/test_upgrade.py
+++ b/cosmo_tester/test_suites/agent/test_upgrade.py
@@ -58,7 +58,6 @@ def test_old_agent_stopped_after_upgrade(ssh_key, module_tmpdir,
 
         create_copy_and_restore_snapshot(
             old_manager, new_manager, snapshot_id, local_snapshot_path, logger,
-            admin_password=old_manager.mgr_password,
             wait_for_post_restore_commands=True)
 
         for agent_os in AGENT_OSES:

--- a/cosmo_tester/test_suites/cluster/cluster_to_aio_agents_migration_test.py
+++ b/cosmo_tester/test_suites/cluster/cluster_to_aio_agents_migration_test.py
@@ -29,8 +29,7 @@ def test_migrate_agents_cluster_to_aio(
 
     create_copy_and_restore_snapshot(
         node1, aio_mgr, snapshot_id, snapshot_path, logger,
-        cert_path=aio_mgr.api_ca_path,
-        admin_password=node1.mgr_password)
+        cert_path=aio_mgr.api_ca_path)
 
     logger.info('Migrating to new agents, stopping old agents')
     aio_mgr.run_command(
@@ -65,8 +64,7 @@ def test_migrate_agents_aio_to_cluster(
 
     create_copy_and_restore_snapshot(
         aio_mgr, node1, snapshot_id, snapshot_path, logger,
-        cert_path=aio_mgr.api_ca_path,
-        admin_password=aio_mgr.mgr_password)
+        cert_path=aio_mgr.api_ca_path)
 
     for mgr in node1, node2, node3:
         # Restart restservice to use correct rest secret

--- a/cosmo_tester/test_suites/multi_net/multi_network_test.py
+++ b/cosmo_tester/test_suites/multi_net/multi_network_test.py
@@ -122,7 +122,6 @@ def test_multiple_networks(managers_and_vms,
 
     create_copy_and_restore_snapshot(
         old_manager, new_manager, snapshot_id, local_snapshot_path, logger,
-        admin_password=old_manager.mgr_password,
         wait_for_post_restore_commands=False)
 
     upgrade_agents(new_manager, logger, test_config)


### PR DESCRIPTION
It is picked up from the old manager object, so was removed as a parameter.