### PR TITLE
Mark AWS images as external resources

### DIFF
--- a/cosmo_tester/resources/infrastructure_blueprints/aws/vm-ipv6.yaml
+++ b/cosmo_tester/resources/infrastructure_blueprints/aws/vm-ipv6.yaml
@@ -134,6 +134,7 @@ node_templates:
   image:
     type: cloudify.nodes.aws.ec2.Image
     properties:
+      use_external_resource: true
       resource_config:
         kwargs:
           Filters:

--- a/cosmo_tester/resources/infrastructure_blueprints/aws/vm-multi-net.yaml
+++ b/cosmo_tester/resources/infrastructure_blueprints/aws/vm-multi-net.yaml
@@ -203,6 +203,7 @@ node_templates:
   image:
     type: cloudify.nodes.aws.ec2.Image
     properties:
+      use_external_resource: true
       resource_config:
         kwargs:
           Filters:

--- a/cosmo_tester/resources/infrastructure_blueprints/aws/vm.yaml
+++ b/cosmo_tester/resources/infrastructure_blueprints/aws/vm.yaml
@@ -133,6 +133,7 @@ node_templates:
   image:
     type: cloudify.nodes.aws.ec2.Image
     properties:
+      use_external_resource: true
       resource_config:
         kwargs:
           Filters:


### PR DESCRIPTION
Otherwise they get deleted... except when they don't.
I'm really not sure how we have NOT seen them be deleted every run.