### PR TITLE
Use RHEL8 for agent VMs on multi-net tests

### DIFF
--- a/cosmo_tester/test_suites/multi_net/multi_network_test.py
+++ b/cosmo_tester/test_suites/multi_net/multi_network_test.py
@@ -29,7 +29,7 @@ def managers_and_vms(ssh_key, module_tmpdir, test_config, logger,
     )
 
     for inst in [2, 3, 4]:
-        hosts.instances[inst] = VM('centos_7', test_config)
+        hosts.instances[inst] = VM('rhel_8', test_config)
 
     passed = True
 


### PR DESCRIPTION
Centos agents currently won't work without python 3 installed.