### PR TITLE
Remove remaining centos 7 agents

### DIFF
--- a/cosmo_tester/test_suites/agent/test_reboot.py
+++ b/cosmo_tester/test_suites/agent/test_reboot.py
@@ -7,8 +7,6 @@ from cosmo_tester.test_suites.agent import validate_agent
 AGENT_OSES = [
     'ubuntu_16_04',
     'centos_8',
-    'centos_7',
-    'rhel_7',
     'rhel_8',
     'windows_2012',
 ]

--- a/cosmo_tester/test_suites/agent/test_upgrade.py
+++ b/cosmo_tester/test_suites/agent/test_upgrade.py
@@ -9,7 +9,7 @@ from cosmo_tester.test_suites.snapshots import (
 from cosmo_tester.test_suites.agent import validate_agent
 
 AGENT_OSES = [
-    'centos_7',
+    'rhel_8',
     'windows_2012',
 ]
 

--- a/cosmo_tester/test_suites/multi_net/multi_network_test.py
+++ b/cosmo_tester/test_suites/multi_net/multi_network_test.py
@@ -166,8 +166,8 @@ def proxy_hosts(request, ssh_key, module_tmpdir, test_config, logger):
     hosts = Hosts(
         ssh_key, module_tmpdir, test_config, logger, request, 3,
         bootstrappable=True,)
-    hosts.instances[0] = VM('centos_7', test_config)
-    hosts.instances[2] = VM('centos_7', test_config)
+    hosts.instances[0] = VM('rhel_8', test_config)
+    hosts.instances[2] = VM('rhel_8', test_config)
     proxy, manager, vm = hosts.instances
 
     passed = True

--- a/cosmo_tester/test_suites/snapshots/conftest.py
+++ b/cosmo_tester/test_suites/snapshots/conftest.py
@@ -16,7 +16,7 @@ def hosts(request, ssh_key, module_tmpdir, test_config, logger):
 
     new_mgr = hosts.instances[0] = VM('master', test_config)
     win_vm = hosts.instances[1] = VM('windows_2012', test_config)
-    lin_vm = hosts.instances[2] = VM('centos_7', test_config)
+    lin_vm = hosts.instances[2] = VM('rhel_8', test_config)
 
     old_mgr_mappings = {}
     for idx, old_mgr in enumerate(old_managers):

--- a/cosmo_tester/test_suites/snapshots/inplace_restore_test.py
+++ b/cosmo_tester/test_suites/snapshots/inplace_restore_test.py
@@ -18,7 +18,7 @@ def manager_and_vm(request, ssh_key, module_tmpdir, test_config,
                    logger):
     hosts = Hosts(ssh_key, module_tmpdir, test_config, logger, request, 2)
     hosts.instances[0] = VM('master', test_config)
-    hosts.instances[1] = VM('centos_7', test_config)
+    hosts.instances[1] = VM('rhel_8', test_config)
     manager, vm = hosts.instances
 
     passed = True


### PR DESCRIPTION
Switched to RH8 in most cases, just removed for actual agent tests.
Can be reintroduced once we handle missing py3 for agent install.