### PR TITLE
Don't test Xenial agent

### DIFF
--- a/cosmo_tester/test_suites/agent/test_reboot.py
+++ b/cosmo_tester/test_suites/agent/test_reboot.py
@@ -5,7 +5,6 @@ from cosmo_tester.framework.test_hosts import Hosts, VM
 from cosmo_tester.test_suites.agent import validate_agent
 
 AGENT_OSES = [
-    'ubuntu_16_04',
     'centos_8',
     'rhel_8',
     'windows_2012',


### PR DESCRIPTION
Agents don't support python 3.5 any more because they use fstrings.
Therefore, let's not test this- and it's in extended support so
we might want to reconsider which Ubuntu versions we test.