### PR TITLE
Update RHEL 7 AMI

### DIFF
--- a/cosmo_tester/config_schemas/platform_aws.yaml
+++ b/cosmo_tester/config_schemas/platform_aws.yaml
@@ -34,7 +34,7 @@ rhel_8_image:
   default: ami-0972eeda2b4a6cb6f
 rhel_7_image:
   description: Image to use for RHEL 7 on this platform.
-  default: ami-020e14de09d1866b4
+  default: ami-06211bde2f9c725e5
 centos_8_image:
   description: Image to use for Centos 8 on this platform.
   default: ami-04f68775f1311a781


### PR DESCRIPTION
The old one appears to have been deleted, though that's not currently reflected in: https://access.redhat.com/solutions/15356#eu_west_1_rhel7