### PR TITLE
Do not pass external_cert/key/ca

### DIFF
--- a/cosmo_tester/test_suites/cluster/cfy_cluster_manager_resources/config_files_templates/manager_config.yaml
+++ b/cosmo_tester/test_suites/cluster/cfy_cluster_manager_resources/config_files_templates/manager_config.yaml
@@ -39,14 +39,11 @@ validations:
 
 
 ssl_inputs:
-  external_cert_path: {{ node.cert_path }}
-  external_key_path: {{ node.key_path }}
   internal_cert_path: {{ node.cert_path }}
   internal_key_path: {{ node.key_path }}
   postgresql_client_cert_path: {{ node.cert_path }}
   postgresql_client_key_path: {{ node.key_path }}
   ca_cert_path: {{ ca_path }}
-  external_ca_cert_path: {{ ca_path }}
 
 prometheus:
   credentials:

--- a/cosmo_tester/test_suites/cluster/conftest.py
+++ b/cosmo_tester/test_suites/cluster/conftest.py
@@ -716,12 +716,9 @@ def _bootstrap_manager_node(node, mgr_num, dbs, brokers, skip_bootstrap_list,
 
     if high_security:
         node.install_config['ssl_inputs'] = {
-            'external_cert_path': node.remote_cert,
-            'external_key_path': node.remote_key,
             'internal_cert_path': node.remote_cert,
             'internal_key_path': node.remote_key,
             'ca_cert_path': node.remote_ca,
-            'external_ca_cert_path': node.remote_ca,
         }
         node.install_config['manager']['security'][
             'ssl_enabled'] = True

--- a/cosmo_tester/test_suites/snapshots/inplace_restore_test.py
+++ b/cosmo_tester/test_suites/snapshots/inplace_restore_test.py
@@ -80,13 +80,9 @@ def test_inplace_restore(manager_and_vm,
         'key_path': '/tmp/ssl_backup/monitoring_key.pem',
     }
     manager.install_config['ssl_inputs'] = {
-        'external_cert_path': '/tmp/ssl_backup/cloudify_external_cert.pem',
-        'external_key_path': '/tmp/ssl_backup/cloudify_external_key.pem',
         'internal_cert_path': '/tmp/ssl_backup/cloudify_internal_cert.pem',
         'internal_key_path': '/tmp/ssl_backup/cloudify_internal_key.pem',
         'ca_cert_path': '/tmp/ssl_backup/cloudify_internal_ca_cert.pem',
-        'external_ca_cert_path':
-            '/tmp/ssl_backup/cloudify_internal_ca_cert.pem',
     }
     manager.bootstrap()
     upload_snapshot(manager, snapshot_path, snapshot_name, logger)


### PR DESCRIPTION
Currently, separate external certs are only supported when public_ip is a domain name, not an ip, and these tests always provide ips.

This is because both internal and external listen on 443, and SNI only works for domain names, not ips.