### PR TITLE
RND-901 Download new rest cert: re-establish the http session

### DIFF
--- a/cosmo_tester/framework/test_hosts.py
+++ b/cosmo_tester/framework/test_hosts.py
@@ -854,6 +854,9 @@ print('{{}} {{}}'.format(distro, codename).lower())
             '/etc/cloudify/ssl/cloudify_internal_ca_cert.pem',
             self.api_ca_path,
         )
+        # close the current restclient session to force making a new connection
+        # using the new certificate, on first use after this call
+        self.client._client._session.close()
 
     @only_manager
     def clean_local_rest_ca(self):

--- a/cosmo_tester/framework/util.py
+++ b/cosmo_tester/framework/util.py
@@ -598,6 +598,8 @@ def delete_deployment(client, deployment_id, logger):
     for _ in range(40):
         found = False
         deployments = client.deployments.list()
+        if not deployments:
+            break
         for deployment in deployments:
             if deployment['id'] == deployment_id:
                 found = True


### PR DESCRIPTION
Close the session after fetching the cert, so that next request re-loads the cert, instead of using the old cert and throwing an error.

Alternatively, we could just send a dummy request, that would fail with a SSLError - that also causes a reload, so the next request would pass. But that would be silly :)

Also speedup `delete_deployment`. Heh.