### PR TITLE
RND-948 Make /cfy_backup/ readable to all

### DIFF
--- a/cosmo_tester/framework/test_hosts.py
+++ b/cosmo_tester/framework/test_hosts.py
@@ -991,6 +991,7 @@ print('{{}} {{}}'.format(distro, codename).lower())
             'Creating Rsync backup for host {}. Might take up to 5 '
             'minutes...'.format(self.deployment_id))
         self.run_command("mkdir /cfy_backup", use_sudo=True)
+        self.run_command("chmod o+r /cfy_backup", use_sudo=True)
         rsync_backup_file = self._tmpdir / 'rsync_backup_{0}'.format(
             self.ip_address)
         locations = ' '.join(RSYNC_LOCATIONS)


### PR DESCRIPTION
This solves the issue of teardown process not being able to restore rsync-ed backups in environment with less lax umask settings.